### PR TITLE
Add display subAttribute to members multi-value attribute of Group schema

### DIFF
--- a/src/lib/schemas/group.js
+++ b/src/lib/schemas/group.js
@@ -17,6 +17,7 @@ export class Group extends Types.Schema {
         new Types.Attribute("string", "displayName", {required: true, description: "A human-readable name for the Group. REQUIRED."}),
         new Types.Attribute("complex", "members", {multiValued: true, uniqueness: false, description: "A list of members of the Group."}, [
             new Types.Attribute("string", "value", {mutable: "immutable", description: "Identifier of the member of this Group."}),
+            new Types.Attribute("string", "display", {mutable: "immutable", description: "Human-readable name of the member of this Group."}),
             new Types.Attribute("reference", "$ref", {mutable: "immutable", referenceTypes: ["User", "Group"], description: "The URI corresponding to a SCIM resource that is a member of this Group."}),
             new Types.Attribute("string", "type", {mutable: "immutable", canonicalValues: ["User", "Group"], description: "A label indicating the type of resource, e.g., 'User' or 'Group'."})
         ])

--- a/test/lib/schemas/group.json
+++ b/test/lib/schemas/group.json
@@ -22,6 +22,11 @@
             "description": "Identifier of the member of this Group."
           },
           {
+            "name": "display", "type": "string", "multiValued": false, "required": false,
+            "caseExact": false, "mutability": "immutable", "returned": "default", "uniqueness": "none",
+            "description": "Human-readable name of the member of this Group."
+          },
+          {
             "name": "$ref", "type": "reference", "referenceTypes": ["User", "Group"], "multiValued": false, "required": false, 
             "caseExact": false, "mutability": "immutable", "returned": "default", "uniqueness": "none",
             "description": "The URI corresponding to a SCIM resource that is a member of this Group."


### PR DESCRIPTION
Adds the immutable string attribute "display" to the members multi-value attribute of the Group schema, whose existence is implied in [RFC7643§2.4](https://datatracker.ietf.org/doc/html/rfc7643#section-2.4), but missing from the Group schema in other sections of the specification.
Resolves #17