### PR TITLE
Fix exception handling in PatchOp's replace operation

### DIFF
--- a/src/lib/messages/patchop.js
+++ b/src/lib/messages/patchop.js
@@ -368,9 +368,8 @@ export class PatchOp {
             // Call remove, then call add!
             try {
                 if (path !== undefined) this.#remove(index, path);
-            } catch (ex) {
-                // Only rethrow if error is anything other than target doesn't exist
-                if (ex.scimType !== "noTarget") throw ex;
+            } catch {
+                // Do nothing, as we're immediately adding a new value, which will enforce actual attribute validity
             }
             
             try {

--- a/test/lib/messages/patchop.json
+++ b/test/lib/messages/patchop.json
@@ -44,6 +44,11 @@
     "replace": [
       {
         "source": {"id": "1234", "userName": "asdf", "name": {"honorificPrefix": "Mr"}},
+        "target": {"id": "1234", "userName": "ghjk", "name": {"honorificPrefix": "Mr"}},
+        "ops": [{"op": "replace", "path": "userName", "value": "ghjk"}]
+      },
+      {
+        "source": {"id": "1234", "userName": "asdf", "name": {"honorificPrefix": "Mr"}},
         "target": {"id": "1234", "userName": "asdf", "name": {"formatted": "Test"}},
         "ops": [{"op": "replace", "path": "name", "value": {"formatted": "Test"}}]
       },


### PR DESCRIPTION
Previously, PatchOp's internal replace operation handling method would rethrow any exceptions thrown when attempting to remove a value before re-adding it, provided it didn't have a `scimType` of `noTarget`. This meant that required attribute values could not be replaced, as the call to remove the required attribute's value threw an exception with a `scimType` of `invalidValue`, despite having the value immediately added back.

Ultimately, all exceptions thrown in the removal phase of the replace operation can safely be discarded, as the subsequent call to re-add the value will perform its own constraint validation, thereby throwing the same relevant exception thrown in the removal phase (fixes #16).

The test fixtures for the PatchOp message class have also been updated to check that replace operations for required attributes behaves as expected.