### PR TITLE
Fix ListResponse pagination handling of 'startIndex' parameter

### DIFF
--- a/src/lib/messages/listresponse.js
+++ b/src/lib/messages/listresponse.js
@@ -27,11 +27,11 @@ export class ListResponse {
      * @property {Number} itemsPerPage - maximum number of items returned in this list response
      */
     constructor(request = [], params = {}) {
-        let outbound = Array.isArray(request),
-            resources = (outbound ? request : request?.Resources ?? []),
-            totalResults = (outbound ? resources.totalResults ?? resources.length : request.totalResults),
-            {sortBy, sortOrder = "ascending"} = params ?? {},
-            {startIndex = 1, count = 20, itemsPerPage = count} = (outbound ? params : request);
+        const outbound = Array.isArray(request);
+        const resources = (outbound ? request : request?.Resources ?? []);
+        const totalResults = (outbound ? resources.totalResults ?? resources.length : request.totalResults);
+        const {sortBy, sortOrder = "ascending"} = params ?? {};
+        const {startIndex = 1, count = 20, itemsPerPage = count} = (outbound ? params : request);
         
         // Verify the ListResponse contents are valid
         if (!outbound && Array.isArray(request.schemas) && (!request.schemas.includes(ListResponse.#id) || request.schemas.length > 1))
@@ -52,14 +52,14 @@ export class ListResponse {
         
         // Handle sorting if sortBy is defined
         if (sortBy !== undefined) {
-            let paths = sortBy.split(".");
+            const paths = sortBy.split(".");
             
             // Do the sort!
             this.Resources = this.Resources.sort((a, b) => {
                 // Resolve target sort values for each side of the comparison (either the "primary" entry, or first entry, in a multi-valued attribute, or the target value)
-                let ta = paths.reduce((res = {}, path = "") => ((!Array.isArray(res[path]) ? res[path] : (res[path].find(v => !!v.primary) ?? res[0])?.value) ?? ""), a),
-                    tb = paths.reduce((res = {}, path = "") => ((!Array.isArray(res[path]) ? res[path] : (res[path].find(v => !!v.primary) ?? res[0])?.value) ?? ""), b),
-                    list = [ta, tb];
+                const ta = paths.reduce((res = {}, path = "") => ((!Array.isArray(res[path]) ? res[path] : (res[path].find(v => !!v.primary) ?? res[0])?.value) ?? ""), a);
+                const tb = paths.reduce((res = {}, path = "") => ((!Array.isArray(res[path]) ? res[path] : (res[path].find(v => !!v.primary) ?? res[0])?.value) ?? ""), b);
+                const list = [ta, tb];
                 
                 // If some or all of the targets are unspecified, sort specified value above unspecified value
                 if (list.some(t => ((t ?? undefined) === undefined)))
@@ -80,9 +80,14 @@ export class ListResponse {
             if (sortOrder === "descending") this.Resources.reverse();
         }
         
+        // If startIndex is within results, offset results to startIndex
+        if ((this.Resources.length >= this.startIndex) && (this.totalResults !== this.Resources.length + this.startIndex - 1)) {
+            this.Resources = this.Resources.slice(this.startIndex-1);
+        }
+        
         // If there are more resources than items per page, paginate the resources
-        if (this.Resources.length > itemsPerPage) {
-            this.Resources = this.Resources.slice(startIndex-1, startIndex+itemsPerPage-1);
+        if (this.Resources.length > this.itemsPerPage) {
+            this.Resources.length = this.itemsPerPage;
         }
     }
 }

--- a/test/lib/messages/listresponse.json
+++ b/test/lib/messages/listresponse.json
@@ -84,6 +84,12 @@
           "itemsPerPage": 5,
           "sourceRange": [6],
           "expected": [6, 7, 8, 9, 10]
+        },
+        {
+          "startIndex": 6,
+          "itemsPerPage": 0,
+          "sourceRange": [6],
+          "expected": []
         }
       ]
     }

--- a/test/lib/messages/listresponse.json
+++ b/test/lib/messages/listresponse.json
@@ -32,29 +32,60 @@
       {"id": 15, "userName": "LidiaH", "name": {"formatted": "Lidia Holloway"}, "date": "2021-10-15T21:37:36.111Z", "number": 15},
       {"id": 16, "userName": "JohannaL", "name": {"formatted": "Johanna Lorenz"}, "date": "2021-07-19T19:39:26.251Z", "number": 16}
     ],
-    "targets": [
-      {
-        "sortBy": "userName",
-        "expected": [1, 8, 5, 2, 7, 13, 16, 14, 12, 15, 3, 4, 11, 9, 10, 6]
-      },
-      {
-        "sortBy": "name.formatted",
-        "sortOrder": "descending",
-        "expected": [6, 10, 9, 11, 4, 3, 15, 12, 14, 16, 13, 7, 2, 5, 8, 1]
-      },
-      {
-        "sortBy": "date",
-        "expected": [5, 10, 16, 1, 3, 7, 4, 6, 2, 13, 12, 11, 15, 14, 9, 8]
-      },
-      {
-        "sortBy": "number",
-        "expected": [6, 8, 9, 1, 12, 2, 13, 14, 4, 7, 10, 5, 11, 3, 15, 16]
-      },
-      {
-        "sortBy": "number",
-        "sortOrder": "descending",
-        "expected": [16, 15, 3, 11, 5, 10, 7, 4, 14, 13, 2, 12, 1, 9, 8, 6]
-      }
-    ]
+    "targets": {
+      "sortBy": [
+        {
+          "sortBy": "userName",
+          "expected": [1, 8, 5, 2, 7, 13, 16, 14, 12, 15, 3, 4, 11, 9, 10, 6]
+        },
+        {
+          "sortBy": "name.formatted",
+          "sortOrder": "descending",
+          "expected": [6, 10, 9, 11, 4, 3, 15, 12, 14, 16, 13, 7, 2, 5, 8, 1]
+        },
+        {
+          "sortBy": "date",
+          "expected": [5, 10, 16, 1, 3, 7, 4, 6, 2, 13, 12, 11, 15, 14, 9, 8]
+        },
+        {
+          "sortBy": "number",
+          "expected": [6, 8, 9, 1, 12, 2, 13, 14, 4, 7, 10, 5, 11, 3, 15, 16]
+        },
+        {
+          "sortBy": "number",
+          "sortOrder": "descending",
+          "expected": [16, 15, 3, 11, 5, 10, 7, 4, 14, 13, 2, 12, 1, 9, 8, 6]
+        }
+      ],
+      "startIndex": [
+        {
+          "startIndex": 11,
+          "expected": [11, 12, 13, 14, 15, 16]
+        },
+        {
+          "startIndex": 11,
+          "itemsPerPage": 5,
+          "expected": [11, 12, 13, 14, 15]
+        },
+        {
+          "length": 100,
+          "startIndex": 11,
+          "itemsPerPage": 5,
+          "expected": [11, 12, 13, 14, 15]
+        },
+        {
+          "startIndex": 6,
+          "itemsPerPage": 5,
+          "sourceRange": [6, 10],
+          "expected": [6, 7, 8, 9, 10]
+        },
+        {
+          "startIndex": 6,
+          "itemsPerPage": 5,
+          "sourceRange": [6],
+          "expected": [6, 7, 8, 9, 10]
+        }
+      ]
+    }
   }
 }


### PR DESCRIPTION
Previously, ListResponse would only paginate the results when the length of the supplied resources array was greater than the supplied `itemsPerPage` value, which defaults to 20. This process did not take into account a supplied `startIndex`, meaning more results were included in a page than expected when `totalResults` was less than `itemsPerPage`, effectively ignoring `startIndex`.

The ListResponse constructor has been modified to account for the supplied `startIndex`, but only if it determines that the list has not already been offset. To determine this, it checks to see if the actual number of non-empty resources being included, plus the `startIndex` offset, is equal to the `totalResults` value. If so, it assumes the results are already offset, and does not offset again (fixes #21). Additionally, the `itemsPerPage` handling has been split into its own check, and will cap the number of resources by setting the `Resources` array's length to the specified `itemsPerPage` value.

For inbound ListResponse messages, parsing of the `startIndex` and `itemsPerPage` parameters has been made less strict, now accepting both positive and negative integers, potentially presented as JSON strings. In the case that a stringified integer is presented, it is parsed into a number. When parsing negative integer values for these parameters, they will be set to their respective minimum numbers. Separate exceptions are now thrown when these constraints are not met for both inbound and outbound ListResponse messages.

The test fixtures for the ListResponse message class have also been updated to reflect these changes, and to verify that pagination is behaving as expected.