### PR TITLE
 Add primary subAttribute to addresses multi-value attribute of User schema

### DIFF
--- a/src/lib/schemas/user.js
+++ b/src/lib/schemas/user.js
@@ -64,7 +64,8 @@ export class User extends Types.Schema {
             new Types.Attribute("string", "region", {description: "The state or region component."}),
             new Types.Attribute("string", "postalCode", {description: "The zip code or postal code component."}),
             new Types.Attribute("string", "country", {description: "The country name component."}),
-            new Types.Attribute("string", "type", {canonicalValues: ["work", "home", "other"], description: "A label indicating the attribute's function, e.g. 'work' or 'home'."})
+            new Types.Attribute("string", "type", {canonicalValues: ["work", "home", "other"], description: "A label indicating the attribute's function, e.g. 'work' or 'home'."}),
+            new Types.Attribute("boolean", "primary", {description: "A Boolean value indicating the 'primary' or preferred attribute value for this attribute, e.g. the preferred mailing address or primary email address. The primary attribute value 'true' MUST appear no more than once."})
         ]),
         new Types.Attribute("complex", "groups", {direction: "out", mutable: false, multiValued: true, uniqueness: false, description: "A list of groups to which the user belongs, either through direct membership, through nested groups, or dynamically calculated."}, [
             new Types.Attribute("string", "value", {direction: "out", mutable: false, description: "The identifier of the User's group."}),

--- a/test/lib/schemas/user.json
+++ b/test/lib/schemas/user.json
@@ -235,6 +235,10 @@
             "name": "type", "type": "string", "multiValued": false, "required": false, "caseExact": false,
             "canonicalValues": ["work", "home", "other"], "mutability": "readWrite", "returned": "default", "uniqueness": "none",
             "description": "A label indicating the attribute's function, e.g. 'work' or 'home'."
+          },
+          {
+            "name": "primary", "type": "boolean", "multiValued": false, "required": false, "mutability": "readWrite", "returned": "default",
+            "description": "A Boolean value indicating the 'primary' or preferred attribute value for this attribute, e.g. the preferred mailing address or primary email address. The primary attribute value 'true' MUST appear no more than once."
           }
         ]
       },


### PR DESCRIPTION
Similar to #17 and #18, this PR adds the missing "primary" sub-attribute to the "addresses" attribute on the User schema.
The "primary" attribute is one of the default sub-attributes for multi-valued attributes as defined in [RFC 7643, section 2.4](https://datatracker.ietf.org/doc/html/rfc7643#section-2.4), with an example of this in demonstrated in [section 8.2](https://datatracker.ietf.org/doc/html/rfc7643#section-8.2).

Okta includes this "primary" sub-attribute on addresses by default.