### PR TITLE
Support Cloudflare Workers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
   "name": "scimmy",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scimmy",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
       "devDependencies": {
         "@types/node": "ts5.4",
         "c8": "^9.1.0",
@@ -811,6 +814,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fill-range": {
       "version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -67,5 +67,8 @@
     "rollup": "^4.14.3",
     "sinon": "^17.0.1",
     "typescript": "^5.4.5"
+  },
+  "dependencies": {
+    "fast-deep-equal": "^3.1.3"
   }
 }

--- a/packager.js
+++ b/packager.js
@@ -29,7 +29,7 @@ export class Packager {
      */
     static #assets = {
         entry: "scimmy.js",
-        externals: ["util"],
+        externals: ["fast-deep-equal"],
         chunks: {
             "lib/config": [`${Packager.paths.src}/lib/config.js`],
             "lib/types": [`${Packager.paths.src}/lib/types.js`],

--- a/src/lib/messages/patchop.js
+++ b/src/lib/messages/patchop.js
@@ -1,4 +1,4 @@
-import {isDeepStrictEqual} from "util";
+import isDeepStrictEqual from "fast-deep-equal";
 import Types from "../types.js";
 
 /**


### PR DESCRIPTION
Fix #24 by removing usage of the `util` package.

With this change, I was able to use the library inside of a Cloudflare Worker.

Unfortunately I had to use an external dependency to provide the deepStrictEqual. On the positive side, [from the posted benchmarks](https://github.com/epoberezkin/fast-deep-equal?tab=readme-ov-file#performance-benchmark), this makes the check quite a bit quicker than the `util` one.