### PR TITLE
Add bespoke `hasChanges` comparison method in `SCIMMY.Messages.PatchOp` class

### DIFF
--- a/packager.js
+++ b/packager.js
@@ -29,7 +29,7 @@ export class Packager {
      */
     static #assets = {
         entry: "scimmy.js",
-        externals: ["util"],
+        externals: [],
         chunks: {
             "lib/config": [`${Packager.paths.src}/lib/config.js`],
             "lib/types": [`${Packager.paths.src}/lib/types.js`],


### PR DESCRIPTION
Currently, the `apply` method of the `SCIMMY.Messages.PatchOp` class utilises the `isDeepStrictEqual` method from the `node:util` library to check whether a resource has ultimately been modified by the patch operations. This method expensively handles all possible data types, and limits usage of SCIMMY to runtime environments that implement the method.

This change removes the dependency on `isDeepStrictEqual` from `node:util` (fixes #24) and replaces it with a bespoke `hasChanges` method that only handles comparison of data types supported by the SCIM protocol. The test fixtures for the PatchOp class have also been updated to check that the `apply` method only returns the resource if it has been modified.