### PR TITLE
In EnterpriseUser schema, make `value` sub-attribute of `manager` complex attribute optional

### DIFF
--- a/src/lib/schemas/enterpriseuser.js
+++ b/src/lib/schemas/enterpriseuser.js
@@ -21,9 +21,9 @@ export class EnterpriseUser extends Types.Schema {
         new Types.Attribute("string", "division", {description: "Identifies the name of a division."}),
         new Types.Attribute("string", "department", {description: "Identifies the name of a department."}),
         new Types.Attribute("complex", "manager", {uniqueness: false, description: "The User's manager.  A complex type that optionally allows service providers to represent organizational hierarchy by referencing the 'id' attribute of another User."}, [
-            new Types.Attribute("string", "value", {required: true, description: "The id of the SCIM resource representing the User's manager.  REQUIRED."}),
-            new Types.Attribute("reference", "$ref", {referenceTypes: ["User"], description: "The URI of the SCIM resource representing the User's manager.  REQUIRED."}),
-            new Types.Attribute("string", "displayName", {mutable: false, description: "The displayName of the User's manager. OPTIONAL and READ-ONLY."})
+            new Types.Attribute("string", "value", {description: "The id of the SCIM resource representing the User's manager."}),
+            new Types.Attribute("reference", "$ref", {referenceTypes: ["User"], description: "The URI of the SCIM resource representing the User's manager."}),
+            new Types.Attribute("string", "displayName", {mutable: false, description: "The displayName of the User's manager."})
         ])
     ]);
     

--- a/test/lib/schemas/enterpriseuser.json
+++ b/test/lib/schemas/enterpriseuser.json
@@ -37,19 +37,19 @@
         "description": "The User's manager.  A complex type that optionally allows service providers to represent organizational hierarchy by referencing the 'id' attribute of another User.",
         "subAttributes": [
           {
-            "name": "value", "type": "string", "multiValued": false, "required": true,
+            "name": "value", "type": "string", "multiValued": false, "required": false,
             "caseExact": false, "mutability": "readWrite", "returned": "default", "uniqueness": "none",
-            "description": "The id of the SCIM resource representing the User's manager.  REQUIRED."
+            "description": "The id of the SCIM resource representing the User's manager."
           },
           {
             "name": "$ref", "type": "reference", "referenceTypes": ["User"], "multiValued": false, "required": false,
             "caseExact": false, "mutability": "readWrite", "returned": "default", "uniqueness": "none",
-            "description": "The URI of the SCIM resource representing the User's manager.  REQUIRED."
+            "description": "The URI of the SCIM resource representing the User's manager."
           },
           {
             "name": "displayName", "type": "string", "multiValued": false, "required": false,
             "caseExact": false, "mutability": "readOnly", "returned": "default", "uniqueness": "none",
-            "description": "The displayName of the User's manager. OPTIONAL and READ-ONLY."
+            "description": "The displayName of the User's manager."
           }
         ]
       }


### PR DESCRIPTION
The current SCIM protocol RFC is confusing as to whether the `manager.value` attribute should be required or optional by default, since it uses both "RECOMMENDED"[^1] and "REQUIRED"[^2]  in descriptions in different sections. It also states "required: false" in the JSON schema representation[^2], immediately after being described as "REQUIRED". 
Further research by @brianpeiris uncovered an errata in the IETF mailing list[^3] where Phil Hunt, the RFC author, implies the use of "REQUIRED" in the attribute's JSON schema description was meant to be "RECOMMENDED", and that the attribute was intended to be optional.

This change updates the `SCIMMY.Schemas.EnterpriseUser` schema to reflect the protocol author's intent, making the `value` sub-attribute of `manager` complex attribute optional (resolves #28). The test fixtures for the `SCIMMY.Schemas.EnterpriseUser` class have also been updated to reflect this change.

[^1]: https://datatracker.ietf.org/doc/html/rfc7643#page-27
[^2]: https://datatracker.ietf.org/doc/html/rfc7643#page-72
[^3]: https://mailarchive.ietf.org/arch/msg/scim/nKiaxUkWW9-L5KiUKLBOoA9GuPc/