### PR TITLE
Throw `500` and `501` errors for missing or invalid handlers in `SCIMMY.Resources.User` and `SCIMMY.Resources.Group`

### DIFF
--- a/src/lib/messages/patchop.js
+++ b/src/lib/messages/patchop.js
@@ -130,14 +130,14 @@ export class PatchOp {
     
     /**
      * Original SCIM Schema resource instance being patched
-     * @type {SCIMMY.Types.Schema|SCIMMY.Types.Schema[]}
+     * @type {SCIMMY.Types.Schema}
      * @private
      */
     #source;
     
     /**
      * Target SCIM Schema resource instance to apply patches to
-     * @type {SCIMMY.Types.Schema|SCIMMY.Types.Schema[]}
+     * @type {SCIMMY.Types.Schema}
      * @private
      */
     #target;
@@ -146,7 +146,7 @@ export class PatchOp {
      * Apply patch operations to a resource as defined by the PatchOp instance
      * @param {SCIMMY.Types.Schema} resource - the schema instance the patch operation will be performed on
      * @param {Function} [finalise] - method to call when all operations are complete, to feed target back through model
-     * @returns {SCIMMY.Types.Schema|SCIMMY.Types.Schema[]} an instance of the resource modified as per the included patch operations
+     * @returns {Promise<SCIMMY.Types.Schema>} an instance of the resource modified as per the included patch operations
      */
     async apply(resource, finalise) {
         // Bail out if message has not been dispatched (i.e. it's not ready yet)

--- a/src/lib/resources/group.js
+++ b/src/lib/resources/group.js
@@ -134,6 +134,8 @@ export class Group extends Types.Resource {
      * await new SCIMMY.Resources.Group("1234").patch({Operations: [{op: "add", path: "members", value: {value: "5678"}}]});
      */
     async patch(message, ctx) {
+        if (!this.id)
+            throw new Types.Error(404, null, "PATCH operation must target a specific resource");
         if (message === undefined)
             throw new Types.Error(400, "invalidSyntax", "Missing message body from PatchOp request");
         if (Object(message) !== message || Array.isArray(message))

--- a/src/lib/resources/group.js
+++ b/src/lib/resources/group.js
@@ -31,7 +31,10 @@ export class Group extends Types.Resource {
     }
     
     /** @private */
-    static #ingress = () => {};
+    static #ingress = () => {
+        throw new Types.Error(501, null, "Method 'ingress' not implemented by resource 'Group'");
+    };
+    
     /** @implements {SCIMMY.Types.Resource.ingress} */
     static ingress(handler) {
         Group.#ingress = handler;
@@ -39,7 +42,10 @@ export class Group extends Types.Resource {
     }
     
     /** @private */
-    static #egress = () => {};
+    static #egress = () => {
+        throw new Types.Error(501, null, "Method 'egress' not implemented by resource 'Group'");
+    };
+    
     /** @implements {SCIMMY.Types.Resource.egress} */
     static egress(handler) {
         Group.#egress = handler;
@@ -47,7 +53,10 @@ export class Group extends Types.Resource {
     }
     
     /** @private */
-    static #degress = () => {};
+    static #degress = () => {
+        throw new Types.Error(501, null, "Method 'degress' not implemented by resource 'Group'");
+    };
+    
     /** @implements {SCIMMY.Types.Resource.degress} */
     static degress(handler) {
         Group.#degress = handler;

--- a/src/lib/resources/group.js
+++ b/src/lib/resources/group.js
@@ -88,7 +88,7 @@ export class Group extends Types.Resource {
         } else {
             try {
                 const source = [await Group.#egress(this, ctx)].flat().shift();
-                if (!source) throw new Types.Error(500, null, "Unexpected empty value returned by handler");
+                if (!(source instanceof Object)) throw new Types.Error(500, null, `Unexpected ${source === undefined ? "empty" : "invalid"} value returned by handler`);
                 else return new Schemas.Group(source, "out", Group.basepath(), this.attributes);
             } catch (ex) {
                 if (ex instanceof Types.Error) throw ex;
@@ -116,7 +116,7 @@ export class Group extends Types.Resource {
         
         try {
             const target = await Group.#ingress(this, new Schemas.Group(instance, "in"), ctx);
-            if (!target) throw new Types.Error(500, null, "Unexpected empty value returned by handler");
+            if (!(target instanceof Object)) throw new Types.Error(500, null, `Unexpected ${target === undefined ? "empty" : "invalid"} value returned by handler`);
             else return new Schemas.Group(target, "out", Group.basepath(), this.attributes);
         } catch (ex) {
             if (ex instanceof Types.Error) throw ex;

--- a/src/lib/resources/group.js
+++ b/src/lib/resources/group.js
@@ -76,10 +76,10 @@ export class Group extends Types.Resource {
      * @returns {SCIMMY.Messages.ListResponse|SCIMMY.Schemas.Group}
      * @example
      * // Retrieve group with ID "1234"
-     * await (new SCIMMY.Resources.Group("1234")).read();
+     * await new SCIMMY.Resources.Group("1234").read();
      * @example
      * // Retrieve groups with a group name starting with "A"
-     * await (new SCIMMY.Resources.Group({filter: 'displayName -sw "A"'})).read();
+     * await new SCIMMY.Resources.Group({filter: 'displayName sw "A"'}).read();
      */
     async read(ctx) {
         if (!this.id) {
@@ -87,7 +87,9 @@ export class Group extends Types.Resource {
                 .map(u => new Schemas.Group(u, "out", Group.basepath(), this.attributes)), this.constraints);
         } else {
             try {
-                return new Schemas.Group([await Group.#egress(this, ctx)].flat().shift(), "out", Group.basepath(), this.attributes);
+                const source = [await Group.#egress(this, ctx)].flat().shift();
+                if (!source) throw new Types.Error(500, null, "Unexpected empty value returned by handler");
+                else return new Schemas.Group(source, "out", Group.basepath(), this.attributes);
             } catch (ex) {
                 if (ex instanceof Types.Error) throw ex;
                 else if (ex instanceof TypeError) throw new Types.Error(400, "invalidValue", ex.message);
@@ -101,10 +103,10 @@ export class Group extends Types.Resource {
      * @returns {SCIMMY.Schemas.Group}
      * @example
      * // Create a new group with displayName "A Group"
-     * await (new SCIMMY.Resources.Group()).write({displayName: "A Group"});
+     * await new SCIMMY.Resources.Group().write({displayName: "A Group"});
      * @example
      * // Set members attribute for group with ID "1234"
-     * await (new SCIMMY.Resources.Group("1234")).write({members: [{value: "5678"}]});
+     * await new SCIMMY.Resources.Group("1234").write({members: [{value: "5678"}]});
      */
     async write(instance, ctx) {
         if (instance === undefined)
@@ -113,10 +115,9 @@ export class Group extends Types.Resource {
             throw new Types.Error(400, "invalidSyntax", `Operation ${!!this.id ? "PUT" : "POST"} expected request body payload to be single complex value`);
         
         try {
-            return new Schemas.Group(
-                await Group.#ingress(this, new Schemas.Group(instance, "in"), ctx),
-                "out", Group.basepath(), this.attributes
-            );
+            const target = await Group.#ingress(this, new Schemas.Group(instance, "in"), ctx);
+            if (!target) throw new Types.Error(500, null, "Unexpected empty value returned by handler");
+            else return new Schemas.Group(target, "out", Group.basepath(), this.attributes);
         } catch (ex) {
             if (ex instanceof Types.Error) throw ex;
             else if (ex instanceof TypeError) throw new Types.Error(400, "invalidValue", ex.message);
@@ -130,7 +131,7 @@ export class Group extends Types.Resource {
      * @returns {SCIMMY.Schemas.Group}
      * @example
      * // Add member to group with ID "1234" with a patch operation (see SCIMMY.Messages.PatchOp)
-     * await (new SCIMMY.Resources.Group("1234")).patch({Operations: [{op: "add", path: "members", value: {value: "5678"}}]});
+     * await new SCIMMY.Resources.Group("1234").patch({Operations: [{op: "add", path: "members", value: {value: "5678"}}]});
      */
     async patch(message, ctx) {
         if (message === undefined)
@@ -138,23 +139,16 @@ export class Group extends Types.Resource {
         if (Object(message) !== message || Array.isArray(message))
             throw new Types.Error(400, "invalidSyntax", "PatchOp request expected message body to be single complex value");
         
-        try {
-            return await Promise.resolve(new Messages.PatchOp(message)
-                .apply(new Schemas.Group([await Group.#egress(this, ctx)].flat().shift()), 
-                    async (instance) => await Group.#ingress(this, instance, ctx)))
-                .then(instance => !instance ? undefined : new Schemas.Group(instance, "out", Group.basepath(), this.attributes));
-        } catch (ex) {
-            if (ex instanceof Types.Error) throw ex;
-            else if (ex instanceof TypeError) throw new Types.Error(400, "invalidValue", ex.message);
-            else throw new Types.Error(404, null, `Resource ${this.id} not found`);
-        }
+        return await new Messages.PatchOp(message)
+            .apply(await this.read(ctx), async (instance) => await this.write(instance, ctx))
+            .then(instance => !instance ? undefined : new Schemas.Group(instance, "out", Group.basepath(), this.attributes));
     }
     
     /** 
      * @implements {SCIMMY.Types.Resource#dispose}
      * @example
      * // Delete group with ID "1234"
-     * await (new SCIMMY.Resources.Group("1234")).dispose();
+     * await new SCIMMY.Resources.Group("1234").dispose();
      */
     async dispose(ctx) {
         if (!this.id)

--- a/src/lib/resources/user.js
+++ b/src/lib/resources/user.js
@@ -31,7 +31,10 @@ export class User extends Types.Resource {
     }
     
     /** @private */
-    static #ingress = () => {};
+    static #ingress = () => {
+        throw new Types.Error(501, null, "Method 'ingress' not implemented by resource 'User'");
+    };
+    
     /** @implements {SCIMMY.Types.Resource.ingress} */
     static ingress(handler) {
         User.#ingress = handler;
@@ -39,7 +42,10 @@ export class User extends Types.Resource {
     }
     
     /** @private */
-    static #egress = () => {};
+    static #egress = () => {
+        throw new Types.Error(501, null, "Method 'egress' not implemented by resource 'User'");
+    };
+    
     /** @implements {SCIMMY.Types.Resource.egress} */
     static egress(handler) {
         User.#egress = handler;
@@ -47,7 +53,10 @@ export class User extends Types.Resource {
     }
     
     /** @private */
-    static #degress = () => {};
+    static #degress = () => {
+        throw new Types.Error(501, null, "Method 'degress' not implemented by resource 'User'");
+    };
+    
     /** @implements {SCIMMY.Types.Resource.degress} */
     static degress(handler) {
         User.#degress = handler;

--- a/src/lib/resources/user.js
+++ b/src/lib/resources/user.js
@@ -88,7 +88,7 @@ export class User extends Types.Resource {
         } else {
             try {
                 const source = [await User.#egress(this, ctx)].flat().shift();
-                if (!source) throw new Types.Error(500, null, "Unexpected empty value returned by handler");
+                if (!(source instanceof Object)) throw new Types.Error(500, null, `Unexpected ${source === undefined ? "empty" : "invalid"} value returned by handler`);
                 else return new Schemas.User(source, "out", User.basepath(), this.attributes);
             } catch (ex) {
                 if (ex instanceof Types.Error) throw ex;
@@ -116,7 +116,7 @@ export class User extends Types.Resource {
         
         try {
             const target = await User.#ingress(this, new Schemas.User(instance, "in"), ctx);
-            if (!target) throw new Types.Error(500, null, "Unexpected empty value returned by handler");
+            if (!(target instanceof Object)) throw new Types.Error(500, null, `Unexpected ${target === undefined ? "empty" : "invalid"} value returned by handler`);
             else return new Schemas.User(target, "out", User.basepath(), this.attributes);
         } catch (ex) {
             if (ex instanceof Types.Error) throw ex;

--- a/src/lib/resources/user.js
+++ b/src/lib/resources/user.js
@@ -134,6 +134,8 @@ export class User extends Types.Resource {
      * await new SCIMMY.Resources.User("1234").patch({Operations: [{op: "add", value: {userName: "someGuy"}}]});
      */
     async patch(message, ctx) {
+        if (!this.id)
+            throw new Types.Error(404, null, "PATCH operation must target a specific resource");
         if (message === undefined)
             throw new Types.Error(400, "invalidSyntax", "Missing message body from PatchOp request");
         if (Object(message) !== message || Array.isArray(message))

--- a/test/hooks/resources.js
+++ b/test/hooks/resources.js
@@ -422,14 +422,30 @@ export default class ResourcesHooks {
             });
             
             if (callsEgress) {
+                (skip ? it.skip : it)("should throw exception for invalid values returned by handler", async () => {
+                    handler.reset();
+                    
+                    for (let value of [true, false, "invalid", null]) {
+                        handler.returns(value);
+                        
+                        await assert.rejects(() => new TargetResource("placeholder").read(),
+                            {name: "SCIMError", status: 500, scimType: null,
+                                message: "Unexpected invalid value returned by handler"},
+                            "Instance method 'read' did not throw exception for invalid values returned by handler");
+                    }
+                });
+                
                 (skip ? it.skip : it)("should throw exception for empty values returned by handler", async () => {
                     handler.reset();
-                    handler.returns(undefined);
                     
-                    await assert.rejects(() => new TargetResource("placeholder").read(),
-                        {name: "SCIMError", status: 500, scimType: null,
-                            message: "Unexpected empty value returned by handler"},
-                        "Instance method 'read' did not throw exception for empty values returned by handler");
+                    for (let value of [undefined, []]) {
+                        handler.returns(value);
+                        
+                        await assert.rejects(() => new TargetResource("placeholder").read(),
+                            {name: "SCIMError", status: 500, scimType: null,
+                                message: "Unexpected empty value returned by handler"},
+                            "Instance method 'read' did not throw exception for empty values returned by handler");
+                    }
                 });
                 
                 (skip ? it.skip : it)("should call egress handler method with originating resource instance as an argument", async () => {
@@ -563,6 +579,18 @@ export default class ResourcesHooks {
                             `Instance method 'write' did not reject 'instance' parameter ${label} for ${name}`);
                     }
                 }
+            });
+            
+            (skip ? it.skip : it)("should throw exception for invalid values returned by handler", async () => {
+                const {ingress: source} = await fixtures;
+                
+                handler.reset();
+                handler.returns(true);
+                
+                await assert.rejects(() => new TargetResource().write(source),
+                    {name: "SCIMError", status: 500, scimType: null,
+                        message: "Unexpected invalid value returned by handler"},
+                    "Instance method 'write' did not throw exception for invalid values returned by handler");
             });
             
             (skip ? it.skip : it)("should throw exception for empty values returned by handler", async () => {

--- a/test/hooks/resources.js
+++ b/test/hooks/resources.js
@@ -5,7 +5,6 @@ import {Resource} from "#@/lib/types/resource.js";
 import {SCIMError} from "#@/lib/types/error.js";
 import {ListResponse} from "#@/lib/messages/listresponse.js";
 import {createSchemaClass} from "./schemas.js";
-import exp from "node:constants";
 
 /**
  * Create a class that extends SCIMMY.Types.Resource, for use in tests
@@ -165,6 +164,14 @@ export default class ResourcesHooks {
                     "Static method 'ingress' was not a function");
             });
             
+            it("should include a fallback private ingress handler", async () => {
+                const {egress: [source]} = await fixtures;
+                
+                await assert.rejects(() => new TargetResource().write(source),
+                    {name: "SCIMError", status: 501, scimType: null, message: /not implemented by resource/},
+                    "Static method 'ingress' did not include fallback private handler");
+            });
+            
             it("should set private ingress handler", async () => {
                 const {egress: [source]} = await fixtures;
                 const spy = sandbox.spy(TargetResource, "ingress");
@@ -206,6 +213,12 @@ export default class ResourcesHooks {
                     "Static method 'egress' was not a function");
             });
             
+            it("should include a fallback private egress handler", async () => {
+                await assert.rejects(() => new TargetResource("placeholder").read(),
+                    {name: "SCIMError", status: 501, scimType: null, message: /not implemented by resource/},
+                    "Static method 'egress' did not include fallback private handler");
+            });
+            
             it("should set private egress handler", async () => {
                 const spy = sandbox.spy(TargetResource, "egress");
                 const error = new Error("Handler Stubbed");
@@ -244,6 +257,12 @@ export default class ResourcesHooks {
                     "Static method 'degress' was not implemented");
                 assert.ok(typeof TargetResource.degress === "function",
                     "Static method 'degress' was not a function");
+            });
+            
+            it("should include a fallback private degress handler", async () => {
+                await assert.rejects(() => new TargetResource("Error").dispose(),
+                    {name: "SCIMError", status: 501, scimType: null, message: /not implemented by resource/},
+                    "Static method 'degress' did not include fallback private handler");
             });
             
             it("should set private degress handler", async () => {

--- a/test/hooks/resources.js
+++ b/test/hooks/resources.js
@@ -679,6 +679,13 @@ export default class ResourcesHooks {
                     "Instance method 'patch' was not a function");
             });
             
+            it("should expect resource instances to have 'id' property", async () => {
+                await assert.rejects(() => new TargetResource().patch(),
+                    {name: "SCIMError", status: 404, scimType: null,
+                        message: "PATCH operation must target a specific resource"},
+                    "Instance method 'patch' did not expect resource instance to have 'id' property");
+            });
+            
             it("should expect 'message' argument to be an object", async () => {
                 const fixtures = [
                     ["string value 'a string'", "a string"],

--- a/test/lib/messages/searchrequest.js
+++ b/test/lib/messages/searchrequest.js
@@ -246,7 +246,7 @@ describe("SCIMMY.Messages.SearchRequest", () => {
         });
         
         it("should return a ListResponse message instance", async () => {
-            assert.ok(await (new SearchRequest()).apply() instanceof ListResponse,
+            assert.ok(await (new SearchRequest()).apply([]) instanceof ListResponse,
                 "Instance method 'apply' did not return an instance of ListResponse");
         });
         


### PR DESCRIPTION
Currently, the read, write, and patch methods of the `SCIMMY.Resources.User` and `SCIMMY.Resources.Group` classes pass return values from declared ingress/egress/degress handlers directly to their corresponding schema classes for instantiation. When these handlers are either missing, or do not return expected values, the schema class constructor will throw a `TypeError` exception, as it expects the supplied value to be an object. This `TypeError` exception is then rethrown as a `SCIMError` exception with `status` and `scimType` properties of values `400` and `invalidValue` respectively, indicating an issue with the request, which is technically incorrect.

This change updates the default `ingress`, `egress`, and `degress` handlers for the `User` and `Group` resource classes to throw a `501 Not Implemented` exception (fixes #39). It also updates the the `read` and `write` methods of these classes to throw a `500 Internal Server Error` when handler implementations return invalid or empty values that cannot be coerced into schema-compliant values (fixes #39). Additionally, the `patch` method of these classes have been updated to call the class `read` and `write` methods to leverage the aforementioned exception handling, instead of calling ingress/egress handlers themselves (fixes #39). The `patch` methods have also been updated to require they are only able to be called for a specific resource, instead of for a list of resources. The test fixtures in the resources hooks have been updated to verify the correct exceptions are being thrown, and that the `patch` method now requires a specific resource.