### PR TITLE
Fix checks of `startIndex` and `itemsPerPage` in ListResponse

### DIFF
--- a/src/lib/messages/listresponse.js
+++ b/src/lib/messages/listresponse.js
@@ -44,7 +44,7 @@ export class ListResponse {
         // Check supplied itemsPerPage and startIndex are valid integers...
         for (let [key, val, min] of Object.entries({itemsPerPage, startIndex}).map(([key, val], index) => ([key, val, index]))) {
             // ...but only expect actual number primitives when preparing an outbound list response
-            if (Number.isNaN(Number.parseInt(val)) || !`${val}`.match(/^-?\d*$/) || (outbound && (typeof val !== "number" || !Number.isInteger(val) || val < min))) {
+            if (Number.isNaN(Number.parseInt(val)) || !`${val}`.match(/^-?\d*$/) || (outbound && (typeof val !== "number" || !Number.isInteger(val)))) {
                 throw new TypeError(`Expected '${key}' parameter to be a ${min ? "positive" : "non-negative"} integer in ListResponse message constructor`);
             }
         }

--- a/src/lib/types/resource.js
+++ b/src/lib/types/resource.js
@@ -295,8 +295,8 @@ export class Resource {
             this.constraints = {
                 ...(typeof sortBy === "string" ? {sortBy} : {}),
                 ...(["ascending", "descending"].includes(sortOrder) ? {sortOrder} : {}),
-                ...(!Number.isNaN(Number(startIndex)) && Number.isInteger(startIndex) ? {startIndex} : {}),
-                ...(!Number.isNaN(Number(count)) && Number.isInteger(count) ? {count} : {})
+                ...(!Number.isNaN(Number(startIndex)) && Number.isInteger(startIndex) ? {startIndex: Math.max(startIndex, 1)} : {}),
+                ...(!Number.isNaN(Number(count)) && Number.isInteger(count) ? {count: Math.max(count, 0)} : {})
             };
         }
     }

--- a/test/lib/messages/listresponse.js
+++ b/test/lib/messages/listresponse.js
@@ -28,16 +28,16 @@ describe("SCIMMY.Messages.ListResponse", () => {
                 "ListResponse instantiated with invalid 'schemas' property");
         });
         
-        it("should expect 'startIndex' parameter to be a positive integer", () => {
-            for (let value of ["a string", -1, 1.5]) {
+        it("should expect 'startIndex' parameter to be a number", () => {
+            for (let value of ["a string", false, {}]) {
                 assert.throws(() => new ListResponse([], {startIndex: value}),
                     {name: "TypeError", message: "Expected 'startIndex' parameter to be a positive integer in ListResponse message constructor"},
                     `ListResponse instantiated with invalid 'startIndex' parameter value '${value}'`);
             }
         });
         
-        it("should expect 'itemsPerPage' parameter to be a positive integer", () => {
-            for (let value of ["a string", -1, 1.5]) {
+        it("should expect 'itemsPerPage' parameter to be a number", () => {
+            for (let value of ["a string", false, {}]) {
                 assert.throws(() => new ListResponse([], {itemsPerPage: value}),
                     {name: "TypeError", message: "Expected 'itemsPerPage' parameter to be a non-negative integer in ListResponse message constructor"},
                     `ListResponse instantiated with invalid 'itemsPerPage' parameter value '${value}'`);


### PR DESCRIPTION
Currently on instantiation, the ListResponse class will check that the `startIndex` and `itemsPerPage` properties are integer values greater than or equal to `1` and `0` respectively, and throw a TypeError if not. This was intended to prevent the use of invalid values in bespoke implementations. According to RFC7644, `startIndex` and `itemsPerPage` values less than this should be treated as being `1` and `0` respectively. This rounding is already implemented in the ListResponse constructor, but is functionally unused, as the constructor will throw the TypeError first.

This change removes the minimum integer value check from the ListResponse constructor (fixes #42), and rounds `startIndex` and `count` integer constraints to their minimum values in the `SCIMMY.Types.Resource` constructor. Test fixtures have also been updated to reflect this change, and will now check for more non-number values in place of non-positive integers.