### PR TITLE
Allow for ESM und CJS Modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,15 @@
     "node": ">=16"
   },
   "main": "./dist/scimmy.js",
-  "types": "./dist/scimmy.d.ts",
   "exports": {
-    "import": "./dist/scimmy.js",
-    "require": "./dist/cjs/scimmy.cjs"
+    "import": {
+      "types": "./dist/scimmy.d.ts",
+      "import": "./dist/scimmy.js"
+    },    
+    "require": {
+      "types": "./dist/scimmy.d.cts",
+      "require": "./dist/scimmy.js"
+    }
   },
   "scripts": {
     "test": "node packager.js -t test",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "node": ">=16"
   },
   "main": "./dist/scimmy.js",
+  "types": "./dist/scimmy.d.ts",
   "exports": {
     "import": {
       "types": "./dist/scimmy.d.ts",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
       "import": "./dist/scimmy.js"
     },    
     "require": {
-      "types": "./dist/scimmy.d.cts",
+      "types": "./dist/scimmy.d.ts",
       "require": "./dist/scimmy.js"
     }
   },


### PR DESCRIPTION
Typescript doesn't recognize the types without module support.