### PR TITLE
Force `caseExact` and `uniqueness` config values to be `true` and `none` when attribute type is `binary`

### DIFF
--- a/src/lib/schemas/user.js
+++ b/src/lib/schemas/user.js
@@ -86,7 +86,7 @@ export class User extends Types.Schema {
             new Types.Attribute("boolean", "primary", {description: "A Boolean value indicating the 'primary' or preferred attribute value for this attribute. The primary attribute value 'true' MUST appear no more than once."})
         ]),
         new Types.Attribute("complex", "x509Certificates", {multiValued: true, uniqueness: false, description: "A list of certificates issued to the User."}, [
-            new Types.Attribute("binary", "value", {description: "The value of an X.509 certificate."}),
+            new Types.Attribute("binary", "value", {description: "The value of an X.509 certificate.", caseExact: true}),
             new Types.Attribute("string", "display", {description: "A human-readable name, primarily used for display purposes. READ-ONLY."}),
             new Types.Attribute("string", "type", {canonicalValues: [], description: "A label indicating the attribute's function."}),
             new Types.Attribute("boolean", "primary", {description: "A Boolean value indicating the 'primary' or preferred attribute value for this attribute. The primary attribute value 'true' MUST appear no more than once."})

--- a/src/lib/types/attribute.js
+++ b/src/lib/types/attribute.js
@@ -45,18 +45,27 @@ const BaseConfiguration = {
             else throw new TypeError(`Cannot add unknown property '${key}' to configuration of ${errorSuffix}`);
         },
         get: (target, key) => {
-            // Always return true for 'caseExact' config value of binary attributes
-            if (type === "binary" && key === "caseExact") return true;
+            // For binary attribute configuration...
+            if (type === "binary") {
+                // ...always return true for 'caseExact', and
+                if (key === "caseExact") return true;
+                // ...always return 'none' for 'uniqueness'
+                if (key === "uniqueness") return "none";
+            }
+            
             // Otherwise, return actual value
-            else return Reflect.get(target, key);
+            return Reflect.get(target, key);
         },
         set: (target, key, value) => {
             // Make sure the property is known before setting any value
             if (!(key in BaseConfiguration.target))
                 throw new TypeError(`Cannot add unknown property '${key}' to configuration of ${errorSuffix}`);
-            // Make sure binary attributes only accept 'caseExact' values of 'true'
+            // Make sure binary attributes only accept 'caseExact' values of true
             if (type === "binary" && key === "caseExact" && value !== true)
                 throw new TypeError(`Attribute type 'binary' must specify 'caseExact' value as 'true' in ${errorSuffix}`);
+            // Make sure binary attributes only accept 'uniqueness' values of 'none'
+            if (type === "binary" && key === "uniqueness" && value !== "none")
+                throw new TypeError(`Attribute type 'binary' must specify 'uniqueness' value as 'none' in ${errorSuffix}`);
             // Make sure required, multiValued, and caseExact are booleans
             if (["required", "multiValued", "caseExact", "shadow"].includes(key) && (value !== undefined && typeof value !== "boolean"))
                 throw new TypeError(`Attribute '${key}' value must be either 'true' or 'false' in ${errorSuffix}`);

--- a/test/lib/schemas/user.json
+++ b/test/lib/schemas/user.json
@@ -324,7 +324,7 @@
         "subAttributes": [
           {
             "name": "value", "type": "binary", "multiValued": false, "required": false,
-            "caseExact": false, "mutability": "readWrite", "returned": "default", "uniqueness": "none",
+            "caseExact": true, "mutability": "readWrite", "returned": "default", "uniqueness": "none",
             "description": "The value of an X.509 certificate."
           },
           {

--- a/test/lib/types/attribute.js
+++ b/test/lib/types/attribute.js
@@ -136,6 +136,28 @@ describe("SCIMMY.Types.Attribute", () => {
             });
         }
         
+        for (let attrib of ["required", "multiValued", "caseExact", "shadow"]) {
+            it(`should only accept boolean '${attrib}' configuration values`, () => {
+                for (let [type, value] of [["string", "a string"], ["number", 1], ["complex", {}], ["date", new Date()]]) {
+                    assert.throws(() => new Attribute("string", "test", {[attrib]: value}),
+                        {name: "TypeError", message: `Attribute '${attrib}' value must be either 'true' or 'false' in attribute definition 'test'`},
+                        `Attribute instantiated with invalid '${attrib}' configuration ${type} value${typeof value === "object" ? "" : ` '${value}'`}`);
+                }
+            });
+        }
+        
+        it("should expect 'caseExact' value to be 'true' when attribute type is 'binary'", () => {
+            assert.throws(() => new Attribute("binary", "test", {caseExact: false}),
+                {name: "TypeError", message: "Attribute type 'binary' must specify 'caseExact' value as 'true' in attribute definition 'test'"},
+                "Attribute instance did not expect 'caseExact' configuration value to be 'true' when attribute type was 'binary'");
+        });
+        
+        it("should expect 'uniqueness' value to be 'none' when attribute type is 'binary'", () => {
+            assert.throws(() => new Attribute("binary", "test", {uniqueness: false}),
+                {name: "TypeError", message: "Attribute type 'binary' must specify 'uniqueness' value as 'none' in attribute definition 'test'"},
+                "Attribute instance did not expect 'uniqueness' configuration value to be 'none' when attribute type was 'binary'");
+        });
+        
         it("should be frozen after instantiation", () => {
             const attribute = new Attribute("string", "test");
             
@@ -188,14 +210,6 @@ describe("SCIMMY.Types.Attribute", () => {
             }
         });
         
-        it("should expect 'caseExact' value to be 'true' when attribute type is 'binary'", () => {
-            const {config} = new Attribute("binary", "test");
-            
-            assert.throws(() => config.caseExact = false,
-                {name: "TypeError", message: "Attribute type 'binary' must specify 'caseExact' value as 'true' in attribute definition 'test'"},
-                "Instance member 'config' did not expect 'caseExact' value to be 'true' when attribute type was 'binary'");
-        });
-        
         for (let attrib of ["canonicalValues", "referenceTypes"]) {
             it(`should not accept invalid '${attrib}' values`, () => {
                 const {config} = new Attribute("string", "test");
@@ -226,6 +240,34 @@ describe("SCIMMY.Types.Attribute", () => {
                     `Instance member 'config' accepted invalid '${attrib}' date value`);
             });
         }
+        
+        for (let attrib of ["required", "multiValued", "caseExact", "shadow"]) {
+            it(`should only accept boolean '${attrib}' values`, () => {
+                const {config} = new Attribute("string", "test");
+                
+                for (let [type, value] of [["string", "a string"], ["number", 1], ["complex", {}], ["date", new Date()]]) {
+                    assert.throws(() => config[attrib] = value,
+                        {name: "TypeError", message: `Attribute '${attrib}' value must be either 'true' or 'false' in attribute definition 'test'`},
+                        `Instance member 'config' accepted invalid '${attrib}' configuration ${type} value${typeof value === "object" ? "" : ` '${value}'`}`);
+                }
+            });
+        }
+        
+        it("should expect 'caseExact' value to be 'true' when attribute type is 'binary'", () => {
+            const {config} = new Attribute("binary", "test");
+            
+            assert.throws(() => config.caseExact = false,
+                {name: "TypeError", message: "Attribute type 'binary' must specify 'caseExact' value as 'true' in attribute definition 'test'"},
+                "Instance member 'config' did not expect 'caseExact' value to be 'true' when attribute type was 'binary'");
+        });
+        
+        it("should expect 'uniqueness' value to be 'none' when attribute type is 'binary'", () => {
+            const {config} = new Attribute("binary", "test");
+            
+            assert.throws(() => config.uniqueness = true,
+                {name: "TypeError", message: "Attribute type 'binary' must specify 'uniqueness' value as 'none' in attribute definition 'test'"},
+                "Instance member 'config' did not expect 'uniqueness' value to be 'none' when attribute type was 'binary'");
+        });
     });
     
     describe("#subAttributes", () => {


### PR DESCRIPTION
Currently, attributes of type `binary` can be defined with a `caseExact` configuration value of `false`, and a `uniqueness` configuration value of anything other than `none`. According to [RFC7643§2.3.6](https://datatracker.ietf.org/doc/html/rfc7643#section-2.3.6), binary attributes are always case-exact and have no uniqueness.

This change ensures attributes with type `binary` will, by default, have `caseExact` and `uniqueness` configuration values of `false` and `none` respectively. It also adds checks to any custom configuration of `binary` attributes to ensure these values cannot be changed (fixes #44). Test fixtures have also been updated to reflect this change, and to more thoroughly check behaviour when invalid attribute configuration is attempted either at instantiation, or afterward.