### PR TITLE
Add support for filtering of complex multi-value attributes in `coerce` method of `SCIMMY.Types.SchemaDefinition`

### DIFF
--- a/src/lib/types/definition.js
+++ b/src/lib/types/definition.js
@@ -155,7 +155,7 @@ export class SchemaDefinition {
             
             // Go through the schema extension definition and directly register any nested schema definitions
             const surplusSchemas = extension.attributes.filter(e => e instanceof SchemaDefinition);
-            for (let definition of surplusSchemas) this.extend(definition);
+            for (let definition of surplusSchemas) this.extend(Object.getPrototypeOf(definition));
         }
         // If every extension is an attribute instance, add them to the schema definition
         else if (extensions.every(e => e instanceof Attribute)) {
@@ -316,7 +316,7 @@ export class SchemaDefinition {
                     
                     try {
                         // Coerce the mixed value, using only namespaced attributes for this extension
-                        target[name] = attribute.coerce(mixedSource, direction, basepath, namespacedFilters.length ? new Filter(namespacedFilters) : undefined);
+                        target[name] = attribute.coerce(mixedSource, direction, basepath, ...(namespacedFilters.length ? [new Filter(namespacedFilters)] : []));
                     } catch (ex) {
                         // Rethrow exception with added context
                         ex.message += ` in schema extension '${name}'`;
@@ -327,7 +327,7 @@ export class SchemaDefinition {
         }
         
         // Go through and apply each filter expression individually to get coerced value
-        return (filter ?? []).reduce((target, filter) => SchemaDefinition.#filter(this, filter, target), target);
+        return (filter ?? [filter]).reduce((target, filter) => SchemaDefinition.#filter(this, filter, target), target);
     }
     
     /**
@@ -392,7 +392,7 @@ export class SchemaDefinition {
             // Go through every value in the data and filter it
             for (let key in data) {
                 // Get the matching attribute or extension definition for the key
-                const attribute = definition.attribute(prefix ? `${prefix}.${key}` : key) ?? {};
+                const attribute = definition.attribute(prefix ? `${prefix}.${key}` : key);
                 
                 if (attribute instanceof SchemaDefinition) {
                     // If there is data in a namespaced key and no namespace filter, or there's an explicit inclusion filter...

--- a/src/lib/types/filter.js
+++ b/src/lib/types/filter.js
@@ -721,9 +721,10 @@ export class Filter extends Array {
                                     }));
                                 
                                 // If there was a filter, some comparator, and no chained attribute name...
-                                if (parts.indexOf(part) === parts.length - 1 && comparator !== undefined)
+                                if (parts.indexOf(part) === parts.length - 1 && comparator !== undefined) {
                                     // ...add the expression as a branch I guess?
-                                    for (let branch of branches) branch.push([negative?.value, spent.join("."), comparator?.value, value?.value]);
+                                    for (let branch of branches) branch.push([negative?.value, spent.join("."), comparator.value, value?.value]);
+                                }
                                 
                                 if (!results.length) {
                                     // Extract results from the filter
@@ -741,7 +742,7 @@ export class Filter extends Array {
                             }
                             // No filter, but if we're at the end of the chain, join the last expression with the results
                             else if (parts.indexOf(part) === parts.length - 1) {
-                                for (let result of results) result.push([negative?.value, spent.join("."), comparator?.value, value?.value]);
+                                for (let result of results) result.push([negative?.value, spent.join("."), comparator.value, value?.value]);
                             }
                         }
                         
@@ -791,7 +792,7 @@ export class Filter extends Array {
             
             // Push all expressions to results, objectifying if necessary
             for (let expression of expressions) {
-                results.push(...(Array.isArray(query) ? (expression.every(t => Array.isArray(t)) ? expression : [expression]) : [Filter.#objectify(expression)]));
+                results.push(...(Array.isArray(query) && expression.every(Array.isArray) ? expression : [Filter.#objectify(expression)]));
             }
         }
         

--- a/src/lib/types/filter.js
+++ b/src/lib/types/filter.js
@@ -261,7 +261,7 @@ export class Filter extends Array {
         const isString = typeof expression === "string";
         
         // Make sure expression is a string, an object, or an array of objects
-        if (!isString && !(Array.isArray(expression) ? expression : [expression]).every(e => Object.getPrototypeOf(e).constructor === Object))
+        if (!isString && !(Array.isArray(expression) ? expression : [expression]).every(e => !!e && Object.getPrototypeOf(e).constructor === Object))
             throw new TypeError("Expected 'expression' parameter to be a string, object, or array of objects in Filter constructor");
         // Make sure the expression string isn't empty
         if (isString && !expression.trim().length)
@@ -289,13 +289,15 @@ export class Filter extends Array {
     match(values) {
         // Match against any of the filters in the set
         return values.filter(value => 
-            this.some(f => (f !== Object(f) ? false : Object.entries(f).every(([attr, expressions]) => {
-                let [,actual] = Object.entries(value).find(([key]) => key.toLowerCase() === attr.toLowerCase()) ?? [];
+            this.some(f => Object.entries(f).every(([attr, expressions]) => {
+                const [,actual] = Object.entries(value).find(([key]) => key.toLowerCase() === attr.toLowerCase()) ?? [];
                 const isActualDate = (actual instanceof Date || (new Date(actual).toString() !== "Invalid Date" && String(actual).match(isoDate)));
                 
                 if (Array.isArray(actual)) {
-                    // Handle multivalued attributes by diving into them
-                    return !!(new Filter(expressions).match(actual).length);
+                    // Handle multivalued attributes by diving into them...
+                    return !!(Array.isArray(expressions) ? expressions : [expressions])
+                        // ...dealing with nested joins involving complex filter expressions
+                        .some(e => new Filter(Array.isArray(e) ? {[attr]: e} : e).match(actual).length);
                 } else if (!Array.isArray(expressions)) {
                     // Handle complex attributes by diving into them
                     return !!(new Filter([expressions]).match([actual]).length);
@@ -370,7 +372,7 @@ export class Filter extends Array {
                     
                     return result;
                 }
-            })))
+            }))
         );
     }
     
@@ -392,7 +394,7 @@ export class Filter extends Array {
             const index = originIndex ?? expressions.indexOf(e)+1;
             const props = Object.entries(e);
             
-            // Make sure the expression isn't empty... 
+            // Make sure the expression isn't empty...
             if (!props.length) {
                 if (!prefix) throw new TypeError(`Missing expression properties for Filter expression object #${index}`);
                 else throw new TypeError(`Missing expressions for property '${prefix.slice(0, -1)}' of Filter expression object #${index}`);
@@ -409,30 +411,34 @@ export class Filter extends Array {
                     const nested = expr.some(e => Array.isArray(e));
                     
                     // Make sure expression is either singular or nested, not both
-                    if (nested && expr.length && !expr.every(e => Array.isArray(e)))
+                    if (nested && expr.length && !expr.every(e => Array.isArray(e) || Object.getPrototypeOf(e).constructor === Object))
                         throw new TypeError(`Unexpected nested array in property '${name}' of Filter expression object #${index}`);
                     
                     // Go through and make sure each expression is valid
                     for (let e of (nested ? expr : [expr])) {
-                        // Extract comparator and expected value
-                        const [comparator, expected] = e.slice(e[0]?.toLowerCase?.() === "not" ? 1 : 0);
-                        
-                        // Make sure there was a comparator
-                        if (!comparator)
-                            throw new TypeError(`Missing comparator in property '${name}' of Filter expression object #${index}`);
-                        // Make sure presence comparators don't include expected values
-                        if (["pr", "np"].includes(comparator.toLowerCase()) && expected !== undefined)
-                            throw new TypeError(`Unexpected comparison value for '${comparator}' comparator in property '${name}' of Filter expression object #${index}`);
-                        // Make sure expected value was defined for any other comparator
-                        if (expected === undefined && !["pr", "np"].includes(comparator.toLowerCase()))
-                            throw new TypeError(`Missing expected comparison value for '${comparator}' comparator in property '${name}' of Filter expression object #${index}`);
+                        // If the expression is a nested object, make sure it's also valid
+                        if (!Array.isArray(e)) Filter.#validate(e, index, name);
+                        else {
+                            // Extract comparator and expected value
+                            const [comparator, expected] = e.slice(e[0]?.toLowerCase?.() === "not" ? 1 : 0);
+                            
+                            // Make sure there was a comparator
+                            if (!comparator || typeof comparator !== "string")
+                                throw new TypeError(`Missing comparator in property '${name}' of Filter expression object #${index}`);
+                            // Make sure presence comparators don't include expected values
+                            if (["pr", "np"].includes(comparator.toLowerCase()) && expected !== undefined)
+                                throw new TypeError(`Unexpected comparison value for '${comparator}' comparator in property '${name}' of Filter expression object #${index}`);
+                            // Make sure expected value was defined for any other comparator
+                            if (expected === undefined && !["pr", "np"].includes(comparator.toLowerCase()))
+                                throw new TypeError(`Missing expected comparison value for '${comparator}' comparator in property '${name}' of Filter expression object #${index}`);
+                        }
                     }
                 }
                 // If expression is an object, traverse it
                 else if (Object.getPrototypeOf(expr).constructor === Object)
                     Filter.#validate(expr, index, `${name}.`);
                 // Otherwise, the expression is not valid
-                else throw new TypeError(`Expected plain object ${name ? `or expression array in property '${name}' of` : "for"} Filter expression object #${index}`)
+                else throw new TypeError(`Expected plain object or expression array in property '${name}' of Filter expression object #${index}`);
             }
         }
         
@@ -456,17 +462,21 @@ export class Filter extends Array {
                         const expressions = [];
                         
                         // Handle logical "and" operations applied to a single attribute
-                        for (let e of expr.every(e => Array.isArray(e)) ? expr : [expr]) {
-                            // Copy expression so original isn't modified
-                            const parts = [...e];
-                            // Then check for negations and extract the actual values
-                            const negate = (parts[0].toLowerCase() === "not" ? parts.shift() : undefined);
-                            const [comparator, expected] = parts;
-                            const maybeValue = expected instanceof Date ? expected.toISOString() : expected;
-                            const value = (typeof maybeValue === "string" ? `"${maybeValue}"` : (maybeValue !== undefined ? `${maybeValue}` : maybeValue))
-                            
-                            // Add the stringified expression to the results
-                            expressions.push([negate, `${prefix}${attr}`, comparator, value].filter(v => !!v).join(" "));
+                        for (let e of expr.every(e => Array.isArray(e) || Object.getPrototypeOf(e).constructor === Object) ? expr : [expr]) {
+                            // If expression isn't simple, update attribute name with complex filters
+                            if (!Array.isArray(e)) attr = `${attr}[${Object.entries(e).map(getMapper())}]`;
+                            else {
+                                // Copy expression so original isn't modified
+                                const parts = [...e];
+                                // Then check for negations and extract the actual values
+                                const negate = (parts[0].toLowerCase() === "not" ? parts.shift() : undefined);
+                                const [comparator, expected] = parts;
+                                const maybeValue = expected instanceof Date ? expected.toISOString() : expected;
+                                const value = (typeof maybeValue === "string" ? `"${maybeValue}"` : (maybeValue !== undefined ? `${maybeValue}` : maybeValue))
+                                
+                                // Add the stringified expression to the results
+                                expressions.push([negate, `${prefix}${attr}`, comparator, value].filter(v => !!v).join(" "));
+                            }
                         }
                         
                         return expressions;
@@ -513,7 +523,7 @@ export class Filter extends Array {
                 if (grouping !== undefined) tokens.push({type: "Group", value: grouping.substring(1, grouping.length - 1)});
                 
                 // Treat complex attribute filters as words
-                if (complex !== undefined) word = tokens.pop().value + complex;
+                if (complex !== undefined) word = tokens.pop()?.value + complex;
                 
                 // Handle attribute names (words), and unescaped string values
                 if (word !== undefined) {
@@ -605,7 +615,7 @@ export class Filter extends Array {
         else if (expressions.every(e => Object.getPrototypeOf(e).constructor === Object)) {
             return expressions.map(Filter.#objectify);
         }
-        // Go through every expression in the list, or handle a singular expression if that's what was given  
+        // Go through every expression in the list, or handle a singular expression if that's what was given
         else {
             const result = {};
             
@@ -631,7 +641,7 @@ export class Filter extends Array {
                         const expression = [negative, comparator.toLowerCase(), value].filter(v => v !== undefined);
                         
                         // Either store the single expression, or convert to array if attribute already has an expression defined
-                        target[name] = (!Array.isArray(target[name]) ? expression : [...(target[name].every(Array.isArray) ? target[name] : [target[name]]), expression]);
+                        target[name] = (target[name] === undefined ? expression : [...(Array.isArray(target[name]) && target[name].every(Array.isArray) ? target[name] : [target[name]]), expression]);
                     }
                 }
             }
@@ -652,12 +662,12 @@ export class Filter extends Array {
         // Initial pass to check for complexities
         const simple = !tokens.some(t => ["Operator", "Group"].includes(t.type));
         // Closer inspection in case word tokens contain nested attribute filters
-        const reallySimple = simple && (tokens[0]?.value ?? tokens[0] ?? "").split(pathSeparator)
+        const reallySimple = simple && tokens[0]?.value.split(pathSeparator)
             .every(t => t === multiValuedFilter.exec(t).slice(1).shift());
         
         // If there's no operators or groups, and no nested attribute filters, assume the expression is complete
         if (reallySimple) {
-            results.push(Array.isArray(query) ? tokens.map(t => t.value ?? t) : Filter.#objectify(tokens.splice(0).map(t => t?.value ?? t)));
+            results.push(Array.isArray(query) ? tokens.map(t => t.value) : Filter.#objectify(tokens.splice(0).map(t => t.value)));
         }
         // Otherwise, logic and groups need to be evaluated
         else {
@@ -691,7 +701,7 @@ export class Filter extends Array {
                         
                         for (let part of parts) {
                             // Check for filters in the path part
-                            const [, key = part, filter] = multiValuedFilter.exec(part) ?? [];
+                            const [, key = part, filter] = multiValuedFilter.exec(part);
                             
                             // Store the spent path part
                             spent.push(key);
@@ -702,14 +712,18 @@ export class Filter extends Array {
                                     // Get any branches in the nested filter, parse them for joins, and properly wrap them
                                     .#operations(Filter.#tokenise(filter.substring(1, filter.length - 1)), "or")
                                     .map(b => Filter.#parse(b))
-                                    .map(b => b.every(b => b.every(b => Array.isArray(b))) ? b.flat(1) : b)
                                     // Prefix any attribute paths with spent parts
                                     .map((branch) => branch.map(join => {
-                                        const negative = (join.length === 4 || (join.length === 3 && comparators.includes(join[join.length-1].toLowerCase())) ? join.shift() : undefined);
+                                        const negative = (join.length === 4 || (join.length === 3 && comparators.includes(join[join.length-1]?.toLowerCase?.())) ? join.shift() : undefined);
                                         const [path, comparator, value] = join;
                                         
-                                        return [negative?.toLowerCase?.(), `${spent.join(".")}.${path}`, comparator, value];
+                                        return [negative?.toLowerCase(), `${spent.join(".")}.${path}`, comparator, value];
                                     }));
+                                
+                                // If there was a filter, some comparator, and no chained attribute name...
+                                if (parts.indexOf(part) === parts.length - 1 && comparator !== undefined)
+                                    // ...add the expression as a branch I guess?
+                                    for (let branch of branches) branch.push([negative?.value, spent.join("."), comparator?.value, value?.value]);
                                 
                                 if (!results.length) {
                                     // Extract results from the filter

--- a/test/lib/types/filter.json
+++ b/test/lib/types/filter.json
@@ -113,6 +113,32 @@
     ],
     "complex": [
       {
+        "source": "emails[type eq \"work\"] pr",
+        "target": [
+          {"emails": [{"type": ["eq", "work"]}, ["pr"]]}
+        ]
+      },
+      {
+        "source": "emails[not type eq \"work\"] pr",
+        "target": [
+          {"emails": [{"type": ["not", "eq", "work"]}, ["pr"]]}
+        ]
+      },
+      {
+        "source": "userType eq \"Employee\" and emails[type eq \"work\" or primary eq true]",
+        "target": [
+          {"userType": ["eq", "Employee"], "emails": {"type": ["eq", "work"]}},
+          {"userType": ["eq", "Employee"], "emails": {"primary": ["eq", true]}}
+        ]
+      },
+      {
+        "source": "userType eq \"Employee\" and emails[type eq \"work\" or primary eq true] pr",
+        "target": [
+          {"userType": ["eq", "Employee"], "emails": [{"type": ["eq", "work"]}, ["pr"]]},
+          {"userType": ["eq", "Employee"], "emails": [{"primary": ["eq", true]}, ["pr"]]}
+        ]
+      },
+      {
         "source": "(name.FamilyName eq \"Employee\" or name.FamilyName eq \"Manager\") and (emails.Value co \"example.com\" or emails.Value co \"example.org\")",
         "target": [
           {"name": {"familyName": ["eq", "Employee"]}, "emails": {"value": ["co", "example.com"]}},
@@ -178,7 +204,8 @@
       {"source": [{"quota": ["gt", 1.5]}], "target": "quota gt 1.5"},
       {"source": [{"userType": ["eq", null]}], "target": "userType eq null"},
       {"source": [{"active": ["eq", false]}], "target": "active eq false"},
-      {"source": [{"emails": {"primary": ["eq", true]}}], "target": "emails.primary eq true"}
+      {"source": [{"emails": {"primary": ["eq", true]}}], "target": "emails.primary eq true"},
+      {"source": [{"date": ["ge", "2021-09-08T23:02:28.986Z"]}], "target": "date ge \"2021-09-08T23:02:28.986Z\""}
     ],
     "logical": [
       {"source": [{"eq": ["not", "pr"]}], "target": "not eq pr"},
@@ -196,6 +223,19 @@
       {"source": [{"not": ["not", "sw", "A"], "userName": [["ew", "Z"], ["co", "m"]]}], "target": "not not sw \"A\" and userName ew \"Z\" and userName co \"m\""}
     ],
     "complex": [
+      {
+        "target": "emails[type eq \"work\"] pr",
+        "source": [
+          {"emails": [{"type": ["eq", "work"]}, ["pr"]]}
+        ]
+      },
+      {
+        "target": "userType eq \"Employee\" and emails[type eq \"work\"] pr or userType eq \"Employee\" and emails[primary eq true] pr",
+        "source": [
+          {"userType": ["eq", "Employee"], "emails": [{"type": ["eq", "work"]}, ["pr"]]},
+          {"userType": ["eq", "Employee"], "emails": [{"primary": ["eq", true]}, ["pr"]]}
+        ]
+      },
       {
         "target": "name.familyName eq \"Employee\" and emails.value co \"example.com\" or name.familyName eq \"Employee\" and emails.value co \"example.org\" or name.familyName eq \"Manager\" and emails.value co \"example.com\" or name.familyName eq \"Manager\" and emails.value co \"example.org\"",
         "source": [
@@ -296,13 +336,15 @@
         {"expression": {"exists": ["ne", null]}, "expected": [1, 3]},
         {"expression": {"exists": ["eq", true]}, "expected": [1]},
         {"expression": {"exists": ["eq", "True"]}, "expected": [1]},
-        {"expression": {"exists": ["eq", "False"]}, "expected": [3]}
+        {"expression": {"exists": ["eq", "False"]}, "expected": [3]},
+        {"expression": {"exists": ["eq", "falsey"]}, "expected": []}
       ],
       "nesting": [
         {"expression": {"name": {"formatted": ["co", "a"]}}, "expected": [1, 2, 4]},
         {"expression": {"name": {"formatted": ["ew", "e"]}}, "expected": [1, 2]},
         {"expression": {"userName": ["co", "A"], "name": {"formatted": ["co", "a"]}}, "expected": [1, 2]},
         {"expression": {"emails": {"type": ["eq", "work"]}}, "expected": [1, 3, 4]},
+        {"expression": {"emails": [{"type": ["eq", "work"]}, ["pr"]]}, "expected": [1, 3, 4]},
         {"expression": {"emails": {"value": ["ew", "example.net"]}}, "expected": [1, 4]},
         {"expression": {"emails": {"type": ["eq", "work"], "value": ["ew", "example.net"]}}, "expected": [1]}
       ],

--- a/test/lib/types/filter.json
+++ b/test/lib/types/filter.json
@@ -119,9 +119,33 @@
         ]
       },
       {
+        "source": "not emails[type eq \"work\"].value pr",
+        "target": [
+          {"emails": {"type": ["eq", "work"], "value": ["not", "pr"]}}
+        ]
+      },
+      {
         "source": "emails[not type eq \"work\"] pr",
         "target": [
           {"emails": [{"type": ["not", "eq", "work"]}, ["pr"]]}
+        ]
+      },
+      {
+        "source": "emails[type eq \"work\"] co \"A\"",
+        "target": [
+          {"emails": [{"type": ["eq", "work"]}, ["co", "A"]]}
+        ]
+      },
+      {
+        "source": "emails[not type eq \"work\"] co \"A\"",
+        "target": [
+          {"emails": [{"type": ["not", "eq", "work"]}, ["co", "A"]]}
+        ]
+      },
+      {
+        "source": "not emails[not type eq \"work\"] co \"A\"",
+        "target": [
+          {"emails": [{"type": ["not", "eq", "work"]}, ["not", "co", "A"]]}
         ]
       },
       {


### PR DESCRIPTION
Currently, the `SCIMMY.Types.Filter` class does not parse comparators for complex filter expressions unless they are followed by a trailing attribute name (i.e. `emails[type eq "work"].value pr` as opposed to `emails[type eq "work"] pr`). When the trailing attribute name is missing, the comparator is ignored and the resulting filter is incomplete. This has flow on effects for the `coerce` method of the `SCIMMY.Types.SchemaDefinition` class, which is no longer instructed to include the `emails` attribute on the coerced value. Additional issues identified include the `coerce` method not evaluating all entries in a supplied filter (or even verifying the filter is an instance of the `Filter` class), and not omitting extension namespaces not explicitly included in a list of expected attribute inclusions.

Whilst technically defined in [RFC7644§3.10](https://datatracker.ietf.org/doc/html/rfc7644#section-3.10) without reference to complex value filters, there is benefit in being capable of parsing and handling these expressions in the `attributes` parameter. Specifically, one would reasonably expect that an `attributes` parameter value of `emails[type eq "work"]` is a request to include only those `emails` that have a `type` value of `work` in the response.

This change adds support in the `Filter` class for parsing comparators of complex filter expressions not followed by trailing attribute names, updating relevant internal methods to account for this scenario. Test fixtures for the `Filter` class have been updated to verify correct parsing and matching of complex filter expressions not followed by trailing attribute names. Leveraging this change, the `coerce` method of the `SchemaDefinition` class has been updated to add support for filtering complex multi-value attributes, only including items that match the given expression in the attribute value (fixes #55). The `coerce` method has also been updated to verify the supplied filter (if any) is an instance of the `Filter` class, evaluate all expressions in a filter, and omit extension namespaces not explicitly included in a list of expected attribute inclusions.