### PR TITLE
Proposal : Augment resources typing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "mocha": "^10.4.0",
         "rollup": "^4.17.2",
         "sinon": "^19.0.2",
-        "typescript": "^5.4.5"
+        "typescript": "^5.6.3"
       },
       "engines": {
         "node": ">=16"
@@ -2298,9 +2298,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
-      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,6 @@
     "mocha": "^10.4.0",
     "rollup": "^4.17.2",
     "sinon": "^19.0.2",
-    "typescript": "^5.4.5"
+    "typescript": "^5.6.3"
   }
 }

--- a/src/lib/resources.js
+++ b/src/lib/resources.js
@@ -11,13 +11,13 @@ import Schemas from "./schemas.js";
  * @namespace SCIMMY.Resources
  * @description
  * SCIMMY provides a singleton class, `SCIMMY.Resources`, that is used to declare resource types implemented by a SCIM Service Provider.
- * It also provides access to supplied implementations of core resource types that can be used to easily support well-known resource types.  
+ * It also provides access to supplied implementations of core resource types that can be used to easily support well-known resource types.
  * It is also used to retrieve a service provider's declared resource types to be sent via the ResourceTypes HTTP endpoint.
- * 
- * > **Note:**  
+ *
+ * > **Note:**
  * > The `SCIMMY.Resources` class is a singleton, which means that declared resource types
  * > will remain the same, regardless of where the class is accessed from within your code.
- * 
+ *
  * ## Declaring Resource Types
  * Resource type implementations can be declared by calling `{@link SCIMMY.Resources.declare}`.
  * This method will add the given resource type implementation to the list of declared resource types, and automatically
@@ -26,33 +26,33 @@ import Schemas from "./schemas.js";
  * // Declare several resource types at once
  * SCIMMY.Resources.declare(SCIMMY.Resources.User, {}).declare(SCIMMY.Resources.Group, {});
  * ```
- * 
+ *
  * Once declared, resource type implementations are made available to the `{@link SCIMMY.Resources.ResourceType}`
  * resource type, which handles formatting them for transmission/consumption according to the ResourceType schema
  * set out in [RFC7643§6](https://datatracker.ietf.org/doc/html/rfc7643#section-6).
- * 
+ *
  * Each resource type implementation must be declared with a unique name, and each name can only be declared once.
- * Attempting to declare a resource type with a name that has already been declared will throw a TypeError with the 
+ * Attempting to declare a resource type with a name that has already been declared will throw a TypeError with the
  * message `"Resource '<name>' already declared"`, where `<name>` is the name of the resource type.
- * 
+ *
  * Similarly, each resource type implementation can only be declared under one name.
  * Attempting to declare an existing resource type under a new name will throw a TypeError with the message
  * `"Resource '<name>' already declared with name '<existing>'"`, where `<name>` and `<existing>` are the targeted name
  * and existing name, respectively, of the resource type.
- * 
+ *
  * ```
  * // Declaring a resource type under a different name
  * class User extends SCIMMY.Types.Resource {/ Your resource type implementation /}
  * SCIMMY.Resources.declare(User, "CustomUser");
  * ```
- * 
+ *
  * ### Extending Resource Types
  * With the exception of the `ResourceType`, `Schema`, and `ServiceProviderConfig` resources, resource type implementations
  * can have schema extensions attached to them via the `{@link SCIMMY.Types.Resource.extend extend}` method inherited from
  * the `{@link SCIMMY.Types.Resource}` class. Schema extensions added to resource type implementations will automatically
  * be included in the `schemaExtensions` attribute when formatted by the `ResourceType` resource, and the extension's
  * schema definition declared to the `{@link SCIMMY.Schemas}` class.
- * 
+ *
  * Resource type implementations can be extended:
  * *   At the time of declaration via the declaration config object:
  *     ```
@@ -71,7 +71,7 @@ import Schemas from "./schemas.js";
  *     // Add the EnterpriseUser schema as an optional extension before declaration
  *     SCIMMY.Resources.User.extend(SCIMMY.Schemas.EnterpriseUser, false);
  *     SCIMMY.Resources.declare(SCIMMY.Resources.User);
- *     
+ *
  *     // Add the EnterpriseUser schema as a required extension during declaration
  *     SCIMMY.Resources.declare(SCIMMY.Resources.User.extend(SCIMMY.Schemas.EnterpriseUser, true));
  *     ```
@@ -80,21 +80,21 @@ import Schemas from "./schemas.js";
  *     // Add the EnterpriseUser schema as a required extension after declaration
  *     SCIMMY.Resources.declared("User").extend(SCIMMY.Schemas.EnterpriseUser, true);
  *     ```
- * 
+ *
  * ## Retrieving Declared Types
  * Declared resource type implementations can be retrieved via the `{@link SCIMMY.Resources.declared}` method.
- * *   All currently declared resource types can be retrieved by calling the method with no arguments.  
+ * *   All currently declared resource types can be retrieved by calling the method with no arguments.
  *     ```
  *     // Returns a cloned object with resource type names as keys, and resource type implementation classes as values
  *     SCIMMY.Resources.declared();
  *     ```
  * *   Specific declared implementations can be retrieved by calling the method with the resource type name string.
- *     This will return the same resource type implementation class that was previously declared.  
+ *     This will return the same resource type implementation class that was previously declared.
  *     ```
  *     // Returns the declared resource matching the specified name, or undefined if no resource matched the name
  *     SCIMMY.Resources.declared("MyResourceType");
  *     ```
- * 
+ *
  * @example <caption>Basic usage with provided resource type implementations</caption>
  * SCIMMY.Resources.declare(SCIMMY.Resources.User)
  *      .ingress((resource, data) => {/ Your handler for creating or modifying user resources /})
@@ -115,23 +115,24 @@ export default class Resources {
      */
     static #internals = [Schema, ResourceType, ServiceProviderConfig];
     /**
-     * Store declared resources for later retrieval 
-     * @private 
+     * Store declared resources for later retrieval
+     * @private
      */
     static #declared = {};
-    
+
     // Expose built-in resources without "declaring" them
     static Schema = Schema;
     static ResourceType = ResourceType;
     static ServiceProviderConfig = ServiceProviderConfig;
     static User = User;
     static Group = Group;
-    
+
     /**
      * Register a resource implementation for exposure as a ResourceType
-     * @param {typeof SCIMMY.Types.Resource} resource - the resource type implementation to register
+     * @template {SCIMMY.Types.Resource} T
+     * @param {T} resource - the resource type implementation to register
      * @param {Object|String} [config] - the configuration to feed to the resource being registered, or the name of the resource type implementation if different to the class name
-     * @returns {typeof SCIMMY.Resources|typeof SCIMMY.Types.Resource} the Resources class or registered resource type class for chaining
+     * @returns {T} the Resources class or registered resource type class for chaining
      */
     static declare(resource, config) {
         // Make sure the registering resource is valid
@@ -143,11 +144,11 @@ export default class Resources {
         // Refuse to declare internal resources
         if (Resources.#internals.includes(resource))
             throw new TypeError(`Refusing to declare internal resource implementation '${resource.name}'`);
-        
+
         // Source name from resource if config is an object
         let name = (typeof config === "string" ? config : resource?.name);
         if (typeof config === "object") name = config.name ?? name;
-        
+
         // Prevent registering a resource implementation under a name that already exists
         if (!!Resources.#declared[name] && Resources.#declared[name] !== resource)
             throw new TypeError(`Resource '${name}' already declared`);
@@ -157,13 +158,13 @@ export default class Resources {
         // All good, register the resource implementation
         else if (!Resources.#declared[name])
             Resources.#declared[name] = resource;
-        
+
         // Set up the resource if a config object was supplied
         if (typeof config === "object") {
             // Register supplied basepath
             if (typeof config.basepath === "string")
                 Resources.#declared[name].basepath(config.basepath);
-            
+
             // Register supplied ingress, egress, and degress methods
             if (typeof config.ingress === "function")
                 Resources.#declared[name].ingress(async (...r) => await config.ingress(...r))
@@ -171,7 +172,7 @@ export default class Resources {
                 Resources.#declared[name].egress(async (...r) => await config.egress(...r))
             if (typeof config.degress === "function")
                 Resources.#declared[name].degress(async (...r) => await config.degress(...r))
-            
+
             // Register any supplied schema extensions
             if (Array.isArray(config.extensions)) {
                 for (let {schema, attributes, required} of config.extensions) {
@@ -179,14 +180,14 @@ export default class Resources {
                 }
             }
         }
-        
+
         // Declare the resource type implementation's schema!
         Schemas.declare(resource.schema.definition);
-        
+
         // If config was supplied, return Resources, otherwise return the registered resource
         return (typeof config === "object" ? Resources : resource);
     }
-    
+
     /**
      * Get registration status of specific resource implementation, or get all registered resource implementations
      * @param {typeof SCIMMY.Types.Resource|String} [resource] - the resource implementation or name to query registration status for

--- a/src/lib/resources/user.js
+++ b/src/lib/resources/user.js
@@ -14,55 +14,67 @@ export class User extends Types.Resource {
     static get endpoint() {
         return "/Users";
     }
-    
+
     /** @private */
     static #basepath;
     /** @implements {SCIMMY.Types.Resource.basepath} */
     static basepath(path) {
         if (path === undefined) return User.#basepath;
         else User.#basepath = (path.endsWith(User.endpoint) ? path : `${path}${User.endpoint}`);
-        
+
         return User;
     }
-    
-    /** @implements {SCIMMY.Types.Resource.schema} */
+
     static get schema() {
         return Schemas.User;
     }
-    
-    /** @private */
-    static #ingress = () => {
+
+    /**
+     * Handler for ingress of a resource
+     * @callback IngressHandler
+     * @param {SCIMMY.Resources.User} resource - the resource performing the ingress
+     * @param {SCIMMY.Schemas.User} instance - an instance of the resource type that conforms to the resource's schema
+     * @param {*} [ctx] - external context in which the handler has been called
+     * @returns {Object} an object to be used to create a new schema instance, whose properties conform to the resource type's schema
+    */
+
+    static #ingress = (() => {
         throw new Types.Error(501, null, "Method 'ingress' not implemented by resource 'User'");
-    };
-    
-    /** @implements {SCIMMY.Types.Resource.ingress} */
+    });
+
+    /**
+     * Sets the method to be called to consume a resource on create
+     * @param {IngressHandler} handler - function to invoke to consume a resource on create
+     * @returns {typeof SCIMMY.Resources.User} this resource type class for chaining
+     * @override
+     */
     static ingress(handler) {
         User.#ingress = handler;
         return User;
     }
-    
+
     /** @private */
     static #egress = () => {
         throw new Types.Error(501, null, "Method 'egress' not implemented by resource 'User'");
     };
-    
+
     /** @implements {SCIMMY.Types.Resource.egress} */
     static egress(handler) {
         User.#egress = handler;
         return User;
     }
-    
+
     /** @private */
     static #degress = () => {
         throw new Types.Error(501, null, "Method 'degress' not implemented by resource 'User'");
     };
-    
+
     /** @implements {SCIMMY.Types.Resource.degress} */
     static degress(handler) {
         User.#degress = handler;
         return User;
     }
-    
+
     /**
      * Instantiate a new SCIM User resource and parse any supplied parameters
      * @extends SCIMMY.Types.Resource
@@ -70,7 +82,7 @@ export class User extends Types.Resource {
     constructor(...params) {
         super(...params);
     }
-    
+
     /**
      * @implements {SCIMMY.Types.Resource#read}
      * @returns {SCIMMY.Messages.ListResponse|SCIMMY.Schemas.User}
@@ -85,7 +97,7 @@ export class User extends Types.Resource {
         try {
             const source = await User.#egress(this, ctx);
             const target = (this.id ? [source].flat().shift() : source);
-            
+
             // If not looking for a specific resource, make sure egress returned an array
             if (!this.id && Array.isArray(target)) return new Messages.ListResponse(target
                 .map(u => new Schemas.User(u, "out", User.basepath(), this.attributes)), this.constraints);
@@ -99,7 +111,7 @@ export class User extends Types.Resource {
             else throw new Types.Error(404, null, `Resource ${this.id} not found`);
         }
     }
-    
+
     /**
      * @implements {SCIMMY.Types.Resource#write}
      * @returns {SCIMMY.Schemas.User}
@@ -115,10 +127,10 @@ export class User extends Types.Resource {
             throw new Types.Error(400, "invalidSyntax", `Missing request body payload for ${!!this.id ? "PUT" : "POST"} operation`);
         if (Object(instance) !== instance || Array.isArray(instance))
             throw new Types.Error(400, "invalidSyntax", `Operation ${!!this.id ? "PUT" : "POST"} expected request body payload to be single complex value`);
-        
+
         try {
             const target = await User.#ingress(this, new Schemas.User(instance, "in"), ctx);
-            
+
             // Make sure ingress returned an object
             if (target instanceof Object) return new Schemas.User(target, "out", User.basepath(), this.attributes);
             // Otherwise, ingress has not been implemented correctly
@@ -129,7 +141,7 @@ export class User extends Types.Resource {
             else throw new Types.Error(404, null, `Resource ${this.id} not found`);
         }
     }
-    
+
     /**
      * @implements {SCIMMY.Types.Resource#patch}
      * @see SCIMMY.Messages.PatchOp
@@ -145,12 +157,12 @@ export class User extends Types.Resource {
             throw new Types.Error(400, "invalidSyntax", "Missing message body from PatchOp request");
         if (Object(message) !== message || Array.isArray(message))
             throw new Types.Error(400, "invalidSyntax", "PatchOp request expected message body to be single complex value");
-        
+
         return await new Messages.PatchOp(message)
             .apply(await this.read(ctx), async (instance) => await this.write(instance, ctx))
             .then(instance => !instance ? undefined : new Schemas.User(instance, "out", User.basepath(), this.attributes));
     }
-    
+
     /**
      * @implements {SCIMMY.Types.Resource#dispose}
      * @example
@@ -160,7 +172,7 @@ export class User extends Types.Resource {
     async dispose(ctx) {
         if (!this.id)
             throw new Types.Error(404, null, "DELETE operation must target a specific resource");
-        
+
         try {
             await User.#degress(this, ctx);
         } catch (ex) {

--- a/src/lib/resources/user.js
+++ b/src/lib/resources/user.js
@@ -45,7 +45,7 @@ export class User extends Types.Resource {
     /**
      * Sets the method to be called to consume a resource on create
      * @param {IngressHandler} handler - function to invoke to consume a resource on create
-     * @returns {typeof SCIMMY.Resources.User} this resource type class for chaining
+     * @returns {SCIMMY.Resources.User} this resource type class for chaining
      * @override
      */
     static ingress(handler) {


### PR DESCRIPTION
Hello ! 👋

I'm just discovering this library (thanks for the awesome work !) and I was struggling with callback typing. I saw the issue #45 and I wanted to share a potential solution.

**Disclaimer** : this PR is draft, the test is only done for the SCIMMY.Resources.User.ingress function.

Since the SCIMMY.Resources.User extends SCIMMY.Types.Resource and bring some override, I notice that typescript handle it better if we define a specific callback type for IngressHandler.

I also changed the return type of SCIMMY.Resources.declare by adding a dynamic type based on the declared type.

Here is an example that you can use in VSCode to test augmented typing.

```js
SCIMMY.Resources.declare(SCIMMY.Resources.User)
    .ingress((resource, data) => {
        /* Handler for creating or modifying user resources */
        console.log('Creating resource:', resource)
        console.log('Data', data)

        const user = {}
        return user
    })

```

Here is an example on how VSCode display the type for ingress.
![image](https://github.com/user-attachments/assets/384349b7-c177-4213-86aa-71652f763d60)
