### PR TITLE
Fix presence filtering of complex multi-value attributes in `SCIMMY.Types.SchemaDefinition`

### DIFF
--- a/test/lib/types/definition.js
+++ b/test/lib/types/definition.js
@@ -594,8 +594,10 @@ describe("SCIMMY.Types.SchemaDefinition", () => {
         for (let [target, outcome, unexpected, expected, filter, multiValued] of [
             ["complex attributes", "filtered positively", "unexpectedly included", {test: {value: "False"}}, "test.value pr"],
             ["complex attributes", "filtered negatively", "unexpectedly excluded", {test: {name: "Test"}}, "test.value np"],
-            ["complex multi-value attributes", "filtered positively", "unexpectedly included", {test: [{name: "Test"}]}, "test.name pr", true],
-            ["complex multi-value attributes", "filtered negatively", "unexpectedly excluded", {test: [{value: "Test"}, {value: "False"}]}, "test.name np", true],
+            ["complex multi-value attributes", "filtered positively", "unexpectedly included", {test: [{name: "Test", value: "Test"}, {name: undefined, value: "False"}]}, "test pr", true],
+            ["complex multi-value attributes", "filtered negatively", "unexpectedly excluded", {}, "test np", true],
+            ["nested complex multi-value attributes", "filtered positively", "unexpectedly included", {test: [{name: "Test"}]}, "test.name pr", true],
+            ["nested complex multi-value attributes", "filtered negatively", "unexpectedly excluded", {test: [{value: "Test"}, {value: "False"}]}, "test.name np", true],
             ["complex multi-value attributes", "matched against filter expressions", "unexpectedly excluded", {test: [{name: "Test", value: "Test"}]}, "test[name eq \"Test\"] pr", true]
         ]) it(`should expect ${target} to be ${outcome}`, () => {
             const source = {test: multiValued ? [{name: "Test", value: "Test"}, {value: "False"}] : {name: "Test", value: "False"}};


### PR DESCRIPTION
Previously, it was possible to include the entire value of a complex multi-value attribute by specifying it in the positive attributes filter of a request (e.g. `?attributes=userName,emails`). Changes introduced in PR #56 to facilitate complex expressions in these filters unexpectedly removed this expected behaviour.

This change returns the `SCIMMY.Types.SchemaDefinition` coerce method to the expected behaviour (fixes #61).
New test fixtures have been added to ensure the behaviour is working as expected and is not unexpectedly removed again.