### PR TITLE
Add `schemas` in `SCIMMY.Messages.PatchOp` documentation and typing

### DIFF
--- a/src/lib/messages/patchop.js
+++ b/src/lib/messages/patchop.js
@@ -50,13 +50,16 @@ const hasChanges = (original, current, keys) => (
  * *   Provides a method to atomically apply PatchOp operations to a resource instance, handling any exceptions that occur along the way.
  */
 export class PatchOp {
+    /** @private */
+    static #id = "urn:ietf:params:scim:api:messages:2.0:PatchOp";
+    
     /**
      * SCIM Patch Operation Message Schema ID
-     * @typedef {String} SCIMMY.Messages.PatchOp~id
-     * @type {String}
-     * @private
+     * @type {"urn:ietf:params:scim:api:messages:2.0:PatchOp"}
      */
-    static #id = "urn:ietf:params:scim:api:messages:2.0:PatchOp";
+    static get id() {
+        return PatchOp.#id;
+    }
     
     /**
      * Whether the PatchOp message has been fully formed.
@@ -76,10 +79,10 @@ export class PatchOp {
     
     /**
      * Instantiate a new SCIM Patch Operation Message with relevant details
-     * @param {Object} request - contents of the patch operation request being performed
-     * @param {SCIMMY.Messages.PatchOp~id[]} request.schemas - list of SCIM-compliant patch schemas
+     * @param {Object} [request] - contents of the patch operation request being performed
+     * @param {typeof SCIMMY.Messages.PatchOp.id[]} request.schemas - list exclusively containing SCIM PatchOp message schema ID
      * @param {SCIMMY.Messages.PatchOp~PatchOpOperation[]} request.Operations - list of SCIM-compliant patch operations to apply to the given resource
-     * @property {SCIMMY.Messages.PatchOp~id[]} schemas - list of SCIM-compliant patch schemas
+     * @property {typeof SCIMMY.Messages.PatchOp.id[]} schemas - list exclusively containing the SCIM PatchOp message schema ID
      * @property {SCIMMY.Messages.PatchOp~PatchOpOperation[]} Operations - list of SCIM-compliant patch operations to apply to the given resource
      */
     constructor(request) {

--- a/src/lib/messages/patchop.js
+++ b/src/lib/messages/patchop.js
@@ -52,6 +52,7 @@ const hasChanges = (original, current, keys) => (
 export class PatchOp {
     /**
      * SCIM Patch Operation Message Schema ID
+     * @typedef {String} SCIMMY.Messages.PatchOp~id
      * @type {String}
      * @private
      */

--- a/src/lib/messages/patchop.js
+++ b/src/lib/messages/patchop.js
@@ -77,7 +77,9 @@ export class PatchOp {
     /**
      * Instantiate a new SCIM Patch Operation Message with relevant details
      * @param {Object} request - contents of the patch operation request being performed
+     * @param {SCIMMY.Messages.PatchOp~id[]} request.schemas - list of SCIM-compliant patch schemas
      * @param {SCIMMY.Messages.PatchOp~PatchOpOperation[]} request.Operations - list of SCIM-compliant patch operations to apply to the given resource
+     * @property {SCIMMY.Messages.PatchOp~id[]} schemas - list of SCIM-compliant patch schemas
      * @property {SCIMMY.Messages.PatchOp~PatchOpOperation[]} Operations - list of SCIM-compliant patch operations to apply to the given resource
      */
     constructor(request) {

--- a/src/lib/types/resource.js
+++ b/src/lib/types/resource.js
@@ -356,7 +356,7 @@ export class Resource {
      * Emits patched resources for consumption with resource's ingress method.
      * @template [T=*] - external context object passed to ingress handler
      * @param {Object} message - the PatchOp message to apply to the received resource
-     * @param {SCIMMY.Messages.PatchOp~id[]} message.schemas - PatchOp schemas
+     * @param {typeof SCIMMY.Messages.PatchOp.id[]} message.schemas - list exclusively containing SCIM PatchOp message schema ID
      * @param {SCIMMY.Messages.PatchOp~PatchOpOperation[]} message.Operations - PatchOp operations to be applied
      * @param {T} [ctx] - any additional context information to pass to the ingress/egress handlers
      * @returns {S} the resource type instance after patching and consumption by ingress method

--- a/src/lib/types/resource.js
+++ b/src/lib/types/resource.js
@@ -356,6 +356,7 @@ export class Resource {
      * Emits patched resources for consumption with resource's ingress method.
      * @template [T=*] - external context object passed to ingress handler
      * @param {Object} message - the PatchOp message to apply to the received resource
+     * @param {SCIMMY.Messages.PatchOp~id[]} message.schemas - PatchOp schemas
      * @param {SCIMMY.Messages.PatchOp~PatchOpOperation[]} message.Operations - PatchOp operations to be applied
      * @param {T} [ctx] - any additional context information to pass to the ingress/egress handlers
      * @returns {S} the resource type instance after patching and consumption by ingress method

--- a/test/lib/messages/patchop.js
+++ b/test/lib/messages/patchop.js
@@ -144,6 +144,23 @@ describe("SCIMMY.Messages.PatchOp", () => {
         });
     });
     
+    describe(".id", () => {
+        it("should be defined", () => {
+            assert.ok("id" in PatchOp,
+                "Static member 'id' not defined");
+        });
+        
+        it("should be a string", () => {
+            assert.ok(typeof PatchOp.id === "string",
+                "Static member 'id' was not a string");
+        });
+        
+        it("should match SCIM Patch Operation Message schema ID", async () => {
+            assert.strictEqual(PatchOp.id, params.id,
+                "Static member 'id' did not match SCIM Patch Operation Message schema ID");
+        });
+    });
+    
     describe("#apply()", () => {
         it("should be implemented", () => {
             assert.ok(typeof (new PatchOp({...template, Operations: [{op: "add", value: {}}]})).apply === "function",


### PR DESCRIPTION
Currently, SCIMMY enforces checks to ensure that schemas on `Resource.Patch` match the expected schema. Please see issue #68 for more details.

However, the typing and documentation don't seem to show this requirement.

This pull request includes changes to:
- the `PatchOp` class in `src/lib/messages/patchop.js` file
- the `Resource` classe in `src/lib/types/resource.js` file

## Details:

### `src/lib/messages/patchop.js`
- Add new typing : `@typedef {String} SCIMMY.Messages.PatchOp~id`
- Add schemas param for constructing new `PatchOp`:  `@param {SCIMMY.Messages.PatchOp~id[]} request.schemas`
### `src/lib/types/resource.js`
- Add schemas param when using `patch` function : `@param {SCIMMY.Messages.PatchOp~id[]} message.schemas`

