### PR TITLE
 Update direction of `externalId` attribute to default value of "both"

### DIFF
--- a/src/lib/types/definition.js
+++ b/src/lib/types/definition.js
@@ -46,7 +46,7 @@ export class SchemaDefinition {
         this.attributes = [
             new Attribute("reference", "schemas", {shadow: true, multiValued: true, referenceTypes: ["uri"]}),
             new Attribute("string", "id", {shadow: true, direction: "out", returned: "always", required: true, mutable: false, caseExact: true, uniqueness: "global"}),
-            new Attribute("string", "externalId", {shadow: true, direction: "in", caseExact: true}),
+            new Attribute("string", "externalId", {shadow: true, caseExact: true}),
             new Attribute("complex", "meta", {shadow: true, required: true, mutable: false}, [
                 new Attribute("string", "resourceType", {required: true, mutable: false, caseExact: true}),
                 new Attribute("dateTime", "created", {direction: "out", mutable: false}),


### PR DESCRIPTION
Currently, the `externalId` common attribute is marked with a direction of "in". This was intended to ensure it is only ever set in incoming requests, but also means it is stripped from outgoing responses.

This change removes the direction configuration from the `externalId` attribute, meaning it defaults to a value of "both", and will no longer be stripped from outgoing responses (fixes #74).