### PR TITLE
Add predefined schema extension attribute accessors to `SCIMMY.Types.Schema` instances

### DIFF
--- a/src/lib/types/definition.js
+++ b/src/lib/types/definition.js
@@ -96,9 +96,9 @@ export class SchemaDefinition {
             const extension = (this.attributes.find(a => a instanceof SchemaDefinition && name.toLowerCase().startsWith(a.id.toLowerCase()))
                 ?? (name.toLowerCase().startsWith(`${this.id.toLowerCase()}:`) || name.toLowerCase() === this.id.toLowerCase() ? this : false));
             // Get the actual attribute name minus extension ID
-            const attribute = (extension ? name.substring(extension.id.length+1) : "");
+            const attribute = (extension ? name.substring(extension.id.length + 1) : "");
             
-            // Bail out if no schema extension found with matching ID 
+            // Bail out if no schema extension found with matching ID
             if (!extension)
                 throw new TypeError(`Schema definition '${this.id}' does not declare schema extension for namespaced target '${name}'`);
             
@@ -245,7 +245,7 @@ export class SchemaDefinition {
         const schemas = [...new Set([
             this.id,
             ...(this.attributes.filter(a => a instanceof SchemaDefinition).map(s => s.id)
-                .filter(id => !!data[id] || Object.keys(data).some(d => d.startsWith(`${id}:`)))),
+                .filter(id => (data[id] !== undefined || Object.entries(data).some(([k, v]) => v !== undefined && k.startsWith(`${id}:`))))),
             ...(Array.isArray(data.schemas) ? data.schemas : [])
         ])];
         
@@ -324,7 +324,7 @@ export class SchemaDefinition {
                         // Start by only dealing with expressions that contain this extension...
                         .map((filter) => Object.entries(filter).filter(([k]) => k.startsWith(`${name}:`))).filter((filter) => filter.length)
                         // ...then remove the extension prefix
-                        .map((filter) => filter.reduce((res, [key, val]) => Object.assign(res, {[key.replace(`${name}:`, "")]: val}), {}))
+                        .map((filter) => filter.reduce((res, [key, val]) => Object.assign(res, {[key.replace(`${name}:`, "")]: val}), {}));
                     
                     try {
                         // Coerce the mixed value, using only namespaced attributes for this extension

--- a/test/lib/types/schema.js
+++ b/test/lib/types/schema.js
@@ -42,12 +42,35 @@ describe("SCIMMY.Types.Schema", () => {
             assert.ok(typeof Schema.extend === "function",
                 "Static method 'extend' was not implemented");
         });
+        
+        it("should expect 'extension' argument to be a Schema class, SchemaDefinition instance, or collection of Attribute instances", () => {
+            assert.throws(() => Schema.extend({}), 
+                {name: "TypeError", message: "Expected 'extension' to be a Schema class, SchemaDefinition instance, or collection of Attribute instances"},
+                "Static method 'extend' did not throw with invalid object input");
+            assert.throws(() => Schema.extend([new Attribute("string", "test"), {}]),
+                {name: "TypeError", message: "Expected 'extension' to be a Schema class, SchemaDefinition instance, or collection of Attribute instances"},
+                "Static method 'extend' did not throw with invalid object input");
+        });
     });
     
     describe(".truncate()", () => {
         it("should be implemented", () => {
             assert.ok(typeof Schema.truncate === "function",
                 "Static method 'truncate' was not implemented");
+        });
+        
+        it("should resolve schema definition instances from Schema classes", () => {
+            const attributes = [new Attribute("string", "aValue"), new Attribute("string", "aString", {returned: false})];
+            const Test = createSchemaClass({attributes});
+            const Extension = createSchemaClass({name: "Extension", id: Test.definition.id.replace("Test", "Extension")});
+            
+            Test.extend(Extension);
+            
+            try {
+                Test.truncate(Extension);
+            } catch (ex) {
+                assert.fail(`Static method 'truncate' did not resolve schema definition instance from Schema class\r\n[cause]: ${ex}`);
+            }
         });
     });
     
@@ -63,6 +86,21 @@ describe("SCIMMY.Types.Schema", () => {
             
             assert.deepStrictEqual(JSON.parse(JSON.stringify(actual)), expected,
                 "Schema instance did not include 'toJSON' method that strips attributes where returned is marked as 'never'");
+        });
+        
+        it("should include 'toJSON' method on schema extension values", () => {
+            const Test = createSchemaClass();
+            const attributes = [new Attribute("string", "aValue"), new Attribute("string", "aString", {returned: false})];
+            const Extension = createSchemaClass({name: "Extension", id: Test.definition.id.replace("Test", "Extension"), attributes});
+            const source = {aValue: "a value"};
+            const expected = {schemas: [Test.definition.id, Extension.definition.id], meta: {resourceType: Test.definition.name}, [Extension.definition.id]: source};
+            
+            Test.extend(Extension);
+            
+            const actual = new Test({[Extension.definition.id]: {...source, aString: "a string"}});
+            
+            assert.deepStrictEqual(JSON.parse(JSON.stringify(actual)), expected,
+                "Schema instance did not include 'toJSON' method on schema extension values");
         });
     });
 });


### PR DESCRIPTION
Currently, the `SCIMMY.Types.Schema` constructor defines accessors for extension schemas, using the extension schema ID as the property name. The set accessor for these properties writes values directly to the underlying resource object, and then prevents extension of this object. Namespaced accessors are also defined for each attribute of the extension schema, which forward accessor operations to the extension schema property. When namespaced extension attribute accessors are used to add properties to the underlying resource object's extension schema value, they attempt to do so to a non-extensible target object. This raises an unintended extensibility exception, and effectively prevents modifying the extension schema value in any way.

This change updates the behaviour of the extension schema accessors, making the get accessor return a new interceding object with all extension attributes predefined as accessors in the same way direct schema attributes are predefined. The extension schema set accessor has also been updated to add or remove the extension schema ID from the `schemas` property, depending on whether the extension has any actual values. Test fixtures for individual `SCIMMY.Schemas.*` classes have been updated to verify extension schema attribute accessors behave as described. A new test fixture has been added to the `SCIMMY.Messages.PatchOp` class suite to verify it correctly handles namespaced attributes, and missing branch coverage has been added to the `SCIMMY.Types.Schema` class suite.