### PR TITLE
Type annotation fixes

### DIFF
--- a/src/lib/types/error.js
+++ b/src/lib/types/error.js
@@ -10,11 +10,11 @@
 export class SCIMError extends Error {
     /**
      * Instantiate a new error with SCIM error details
-     * @param {Number} status - HTTP status code to be sent with the error
-     * @param {String|null} scimType - the SCIM detail error keyword as per [RFC7644§3.12]{@link https://datatracker.ietf.org/doc/html/rfc7644#section-3.12}
+     * @param {SCIMMY.Messages.ErrorResponse~ValidStatusCodes} status - HTTP status code to be sent with the error
+     * @param {SCIMMY.Messages.ErrorResponse~ValidScimTypes|null} scimType - the SCIM detail error keyword as per [RFC7644§3.12]{@link https://datatracker.ietf.org/doc/html/rfc7644#section-3.12}
      * @param {String} message - a human-readable description of what caused the error to occur
-     * @property {Number} status - HTTP status code to be sent with the error
-     * @property {String|null} scimType - the SCIM detail error keyword as per [RFC7644§3.12]{@link https://datatracker.ietf.org/doc/html/rfc7644#section-3.12}
+     * @property {SCIMMY.Messages.ErrorResponse~ValidStatusCodes} status - HTTP status code to be sent with the error
+     * @property {SCIMMY.Messages.ErrorResponse~ValidScimTypes|null} scimType - the SCIM detail error keyword as per [RFC7644§3.12]{@link https://datatracker.ietf.org/doc/html/rfc7644#section-3.12}
      * @property {String} message - a human-readable description of what caused the error to occur
      */
     constructor(status, scimType, message) {

--- a/src/lib/types/error.js
+++ b/src/lib/types/error.js
@@ -11,10 +11,10 @@ export class SCIMError extends Error {
     /**
      * Instantiate a new error with SCIM error details
      * @param {Number} status - HTTP status code to be sent with the error
-     * @param {String} scimType - the SCIM detail error keyword as per [RFC7644§3.12]{@link https://datatracker.ietf.org/doc/html/rfc7644#section-3.12}
+     * @param {String|null} scimType - the SCIM detail error keyword as per [RFC7644§3.12]{@link https://datatracker.ietf.org/doc/html/rfc7644#section-3.12}
      * @param {String} message - a human-readable description of what caused the error to occur
      * @property {Number} status - HTTP status code to be sent with the error
-     * @property {String} scimType - the SCIM detail error keyword as per [RFC7644§3.12]{@link https://datatracker.ietf.org/doc/html/rfc7644#section-3.12}
+     * @property {String|null} scimType - the SCIM detail error keyword as per [RFC7644§3.12]{@link https://datatracker.ietf.org/doc/html/rfc7644#section-3.12}
      * @property {String} message - a human-readable description of what caused the error to occur
      */
     constructor(status, scimType, message) {

--- a/src/lib/types/resource.js
+++ b/src/lib/types/resource.js
@@ -1,6 +1,5 @@
 import {SCIMError} from "./error.js";
 import {SchemaDefinition} from "./definition.js";
-import {Schema} from "./schema.js";
 import {Filter} from "./filter.js";
 
 /**

--- a/src/lib/types/resource.js
+++ b/src/lib/types/resource.js
@@ -250,8 +250,11 @@ export class Resource {
     
     /**
      * Instantiate a new SCIM resource and parse any supplied parameters
-     * @param {String} [id] - the ID of the requested resource
-     * @param {Object} [config={}] - the parameters of the resource instance request
+     * @overload
+     * @description Create a new resource instance without any parameters
+     *
+     * @overload
+     * @param {Object} config - the parameters of the resource instance request
      * @param {String} [config.filter] - the filter to be applied on ingress/egress by implementing resource
      * @param {String} [config.excludedAttributes] - the comma-separated string list of attributes or filters to exclude on egress
      * @param {String} [config.attributes] - the comma-separated string list of attributes or filters to include on egress
@@ -259,6 +262,20 @@ export class Resource {
      * @param {String} [config.sortOrder] - the direction retrieved resources should be sorted in
      * @param {Number} [config.startIndex] - offset index that retrieved resources should start from
      * @param {Number} [config.count] - maximum number of retrieved resources that should be returned in one operation
+     * @description Create a new resource instance with configuration parameters
+     *
+     * @overload
+     * @param {String} id - the ID of the requested resource
+     * @param {Object} [config] - the parameters of the resource instance request
+     * @param {String} [config.filter] - the filter to be applied on ingress/egress by implementing resource
+     * @param {String} [config.excludedAttributes] - the comma-separated string list of attributes or filters to exclude on egress
+     * @param {String} [config.attributes] - the comma-separated string list of attributes or filters to include on egress
+     * @param {String} [config.sortBy] - the attribute retrieved resources should be sorted by
+     * @param {String} [config.sortOrder] - the direction retrieved resources should be sorted in
+     * @param {Number} [config.startIndex] - offset index that retrieved resources should start from
+     * @param {Number} [config.count] - maximum number of retrieved resources that should be returned in one operation
+     * @description Create a new resource instance with an ID and optional configuration parameters
+     * 
      * @property {String} [id] - ID of the resource instance being targeted
      * @property {SCIMMY.Types.Filter} [filter] - filter parsed from the supplied config
      * @property {SCIMMY.Types.Filter} [attributes] - attributes or excluded attributes parsed from the supplied config


### PR DESCRIPTION
I've been working on a Koa+typescript port of scimmy-routers, and these were some issues that came up along the way.

1. First, the parameters for `SCIMError` should use the appropriate union types.
2. `scimType` is often (always?) passed `null` in scimmy-routers, but this is disallowed by the type signatures.
3. There is an unused import in `resource.js`
4. The constructor for `Types.Resource` is incomplete. As-is, the type signature doesn't accept the value of `config` for the first argument. Marking a parameter as optional does not allow subsequent arguments to be passed in its place. Instead, you must provide an `@overload` for each valid signature.

I'm not sure whether these changes are interesting to you, but I figured I'd provide the backported (typescript -> jsdoc) version in case someone else might run up against these.