### PR TITLE
Improve type definition for Filter

### DIFF
--- a/src/lib/types/filter.js
+++ b/src/lib/types/filter.js
@@ -39,6 +39,7 @@ const isoDate = /^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12
 
 /**
  * SCIM Filter Type
+ * @template {SCIMMY.Types.Schema} [S=*] - The object the filter applies on
  * @alias SCIMMY.Types.Filter
  * @summary
  * *   Parses SCIM [filter expressions](https://datatracker.ietf.org/doc/html/rfc7644#section-3.4.2.2) into object representations of the filter expression.
@@ -278,8 +279,8 @@ export class Filter extends Array {
     
     /**
      * Compare and filter a given set of values against this filter instance
-     * @param {Object[]} values - values to evaluate filters against
-     * @returns {Object[]} subset of values that match any expressions of this filter instance
+     * @param {S[]} values - values to evaluate filters against
+     * @returns {S[]} subset of values that match any expressions of this filter instance
      */
     match(values) {
         // Match against any of the filters in the set

--- a/src/lib/types/resource.js
+++ b/src/lib/types/resource.js
@@ -260,8 +260,8 @@ export class Resource {
      * @param {Number} [config.startIndex] - offset index that retrieved resources should start from
      * @param {Number} [config.count] - maximum number of retrieved resources that should be returned in one operation
      * @property {String} [id] - ID of the resource instance being targeted
-     * @property {SCIMMY.Types.Filter} [filter] - filter parsed from the supplied config
-     * @property {SCIMMY.Types.Filter} [attributes] - attributes or excluded attributes parsed from the supplied config
+     * @property {SCIMMY.Types.Filter<S>} [filter] - filter parsed from the supplied config
+     * @property {SCIMMY.Types.Filter<S>} [attributes] - attributes or excluded attributes parsed from the supplied config
      * @property {SCIMMY.Messages.ListResponse~ListConstraints} [constraints] - sort and pagination properties parsed from the supplied config
      * @property {String} [constraints.sortBy] - the attribute retrieved resources should be sorted by
      * @property {String} [constraints.sortOrder] - the direction retrieved resources should be sorted in


### PR DESCRIPTION
The type was missing the schema on which the filter applies Also specify that the `resource.filter.match` method expects an array of the corresponding Schema.