### PR TITLE
Fix(SCIMMY.Messages.PatchOp): empty array error on custom extension

### DIFF
--- a/src/lib/messages/patchop.js
+++ b/src/lib/messages/patchop.js
@@ -380,7 +380,7 @@ export class PatchOp {
                         // Filter out any values that exist in removals list
                         target[property] = (target[property] ?? []).filter(v => !removals.includes(v));
                         // Unset the property if it's now empty
-                        if (target[property].length === 0) target[property] = undefined;
+                        if ((target[property] ?? []).length === 0) target[property] = undefined;
                     }
                 } catch (ex) {
                     if (ex instanceof Types.Error) {

--- a/src/lib/types/filter.js
+++ b/src/lib/types/filter.js
@@ -283,7 +283,7 @@ export class Filter extends Array {
      */
     match(values) {
         // Match against any of the filters in the set
-        return values.filter(value => 
+        return values?.filter(value => 
             this.some(f => Object.entries(f).every(([attr, expressions]) => {
                 const [,actual] = Object.entries(value).find(([key]) => key.toLowerCase() === attr.toLowerCase()) ?? [];
                 const isActualDate = (actual instanceof Date || (new Date(actual).toString() !== "Invalid Date" && String(actual).match(isoDate)));


### PR DESCRIPTION
When running a "Remove" patch operation on an array in a custom extension I get the error:

`Cannot read properties of undefined (reading 'length')`

The error arises in `patchop.js` on line 383:

patchop.js:380-383
```js
// Filter out any values that exist in removals list
target[property] = (target[property] ?? []).filter(v => !removals.includes(v));
// Unset the property if it's now empty
if (target[property]).length === 0) target[property] = undefined; // <----
```

The issue arises because `target[property]` is a schema instance, which returns `undefined` when it has no values.

schema.js:204
```js
if (!hasActualValues(resource[extension.id] ?? {})) return undefined;
```

This PR fixes the issue by safeguarding the `.length` call by coalescing to an empty array if `target[property]` is nullish. 